### PR TITLE
Updated to null-safety, removed Firebase from Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
   
     <application>
 
-        <service
+        <!-- <service
             android:name=".services.firebase.FCMService"
             android:exported="false">
             <intent-filter>
@@ -32,7 +32,7 @@
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="me.carda.awesome_notifications.firebase.background_channel"/>
+            android:value="me.carda.awesome_notifications.firebase.background_channel"/> -->
 
         <receiver android:name=".notifications.broadcastReceivers.DismissedNotificationReceiver"/>
         <receiver android:name=".notifications.broadcastReceivers.ScheduledNotificationReceiver"/>

--- a/android/src/main/java/me/carda/awesome_notifications/AwesomeNotificationsPlugin.java
+++ b/android/src/main/java/me/carda/awesome_notifications/AwesomeNotificationsPlugin.java
@@ -109,7 +109,7 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
         }*/
 
         /// Firebase services depends on Google Play services
-        return true;
+        return false;
     }
 
     @Override
@@ -174,24 +174,24 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
 
         getApplicationLifeCycle();
 
-        enableFirebase(context);
+        // enableFirebase(context);
     }
 
-    private void enableFirebase(Context context){
+    // private void enableFirebase(Context context){
 
-        Integer resourceId = context.getResources().getIdentifier("google_api_key", "string", context.getPackageName());
+    //     Integer resourceId = context.getResources().getIdentifier("google_api_key", "string", context.getPackageName());
 
-        if(resourceId == 0){
-            Log.d(TAG, "Firebase file not found.");
-            firebaseEnabled = false;
-            return;
-        }
+    //     if(resourceId == 0){
+    //         Log.d(TAG, "Firebase file not found.");
+    //         firebaseEnabled = false;
+    //         return;
+    //     }
 
-        Log.d(TAG, "Enabling firebase for resource id "+resourceId.toString()+"...");
-        FirebaseApp.initializeApp(context);
-        firebaseEnabled = true;
-        Log.d(TAG, "Firebase enabled");
-    }
+    //     Log.d(TAG, "Enabling firebase for resource id "+resourceId.toString()+"...");
+    //     FirebaseApp.initializeApp(context);
+    //     firebaseEnabled = true;
+    //     Log.d(TAG, "Firebase enabled");
+    // }
 
     @Override
     public void onAttachedToActivity(ActivityPluginBinding activityPluginBinding) {
@@ -233,9 +233,9 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
 
         switch (action){
 
-            case Definitions.BROADCAST_FCM_TOKEN:
-                onBroadcastNewFcmToken(intent);
-                return;
+            // case Definitions.BROADCAST_FCM_TOKEN:
+            //     onBroadcastNewFcmToken(intent);
+            //     return;
 
             case Definitions.BROADCAST_CREATED_NOTIFICATION:
                 onBroadcastNotificationCreated(intent);
@@ -263,10 +263,10 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
         }
     }
 
-    private void onBroadcastNewFcmToken(Intent intent) {
-        String token = intent.getStringExtra(Definitions.EXTRA_BROADCAST_FCM_TOKEN);
-        pluginChannel.invokeMethod(Definitions.CHANNEL_METHOD_NEW_FCM_TOKEN, token);
-    }
+    // private void onBroadcastNewFcmToken(Intent intent) {
+    //     String token = intent.getStringExtra(Definitions.EXTRA_BROADCAST_FCM_TOKEN);
+    //     pluginChannel.invokeMethod(Definitions.CHANNEL_METHOD_NEW_FCM_TOKEN, token);
+    // }
 
     private void onBroadcastNotificationCreated(Intent intent) {
 
@@ -428,11 +428,11 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
                 return;
 
             case Definitions.CHANNEL_METHOD_GET_FCM_TOKEN:
-                channelMethodGetFcmToken(call, result);
+                // channelMethodGetFcmToken(call, result);
                 return;
 
             case Definitions.CHANNEL_METHOD_IS_FCM_AVAILABLE:
-                channelMethodIsFcmAvailable(call, result);
+                // channelMethodIsFcmAvailable(call, result);
                 return;
 
             case Definitions.CHANNEL_METHOD_IS_NOTIFICATION_ALLOWED:
@@ -762,52 +762,52 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
         }
     }
 
-    private void channelMethodIsFcmAvailable(MethodCall call, Result result) {
-        try {
-            result.success(hasGooglePlayServices && firebaseEnabled && FirebaseMessaging.getInstance() != null);
-        } catch (Exception e) {
-            Log.w(TAG, "FCM could not enabled for this project.", e);
-            result.success(false );
-        }
-    }
+    // private void channelMethodIsFcmAvailable(MethodCall call, Result result) {
+    //     try {
+    //         result.success(hasGooglePlayServices && firebaseEnabled && FirebaseMessaging.getInstance() != null);
+    //     } catch (Exception e) {
+    //         Log.w(TAG, "FCM could not enabled for this project.", e);
+    //         result.success(false );
+    //     }
+    // }
 
-    private void channelMethodGetFcmToken(MethodCall call, final Result result) {
+    // private void channelMethodGetFcmToken(MethodCall call, final Result result) {
 
-        if(!hasGooglePlayServices){
-            result.notImplemented();
-            return;
-        }
+    //     if(!hasGooglePlayServices){
+    //         result.notImplemented();
+    //         return;
+    //     }
 
-        try {
+    //     try {
 
-            if(!firebaseEnabled){
-                throw new PushNotificationException("Firebase is not enabled for this project");
-            }
+    //         if(!firebaseEnabled){
+    //             throw new PushNotificationException("Firebase is not enabled for this project");
+    //         }
 
-            FirebaseMessaging
-                    .getInstance()
-                    .getToken()
-                    .addOnCompleteListener(new OnCompleteListener<String>() {
-                        @Override
-                        public void onComplete(@NonNull Task<String> task) {
+    //         FirebaseMessaging
+    //                 .getInstance()
+    //                 .getToken()
+    //                 .addOnCompleteListener(new OnCompleteListener<String>() {
+    //                     @Override
+    //                     public void onComplete(@NonNull Task<String> task) {
 
-                            if (!task.isSuccessful()) {
-                                Exception exception = task.getException();
-                                Log.w(TAG, "Fetching FCM registration token failed", exception);
-                                result.error(exception.getMessage() ,"Fetching FCM registration token failed", exception);
-                                return;
-                            }
+    //                         if (!task.isSuccessful()) {
+    //                             Exception exception = task.getException();
+    //                             Log.w(TAG, "Fetching FCM registration token failed", exception);
+    //                             result.error(exception.getMessage() ,"Fetching FCM registration token failed", exception);
+    //                             return;
+    //                         }
 
-                            // Get new FCM registration token
-                            String token = task.getResult();
-                            result.success(token);
-                        }
-                    });
+    //                         // Get new FCM registration token
+    //                         String token = task.getResult();
+    //                         result.success(token);
+    //                     }
+    //                 });
 
-        } catch (Exception e){
-            result.error("Firebase service not available (check if you have google-services.json file)", e.getMessage(), e);
-        }
-    }
+    //     } catch (Exception e){
+    //         result.error("Firebase service not available (check if you have google-services.json file)", e.getMessage(), e);
+    //     }
+    // }
 
     public static Boolean isNotificationEnabled(Context context){
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -849,7 +849,7 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
             Map<String, Object> platformParameters = call.arguments();
 
             String defaultIconPath = (String) platformParameters.get(Definitions.DEFAULT_ICON);
-            Boolean firebaseEnabled = (Boolean) platformParameters.get(Definitions.FIREBASE_ENABLED);
+            Boolean firebaseEnabled = false;
             channelsData = (List<Object>) platformParameters.get(Definitions.INITIALIZE_CHANNELS);
 
             setDefaultConfigurations(
@@ -859,7 +859,7 @@ public class AwesomeNotificationsPlugin extends BroadcastReceiver implements Flu
                 channelsData
             );
 
-            Log.d(TAG, "Push notification service initialized");
+            // Log.d(TAG, "Push notification service initialized");
             result.success(true);
 
         } catch (Exception e){

--- a/android/src/main/java/me/carda/awesome_notifications/Definitions.java
+++ b/android/src/main/java/me/carda/awesome_notifications/Definitions.java
@@ -162,7 +162,7 @@ public interface Definitions {
     String NOTIFICATION_ALLOW_WHILE_IDLE = "allowWhileIdle";
 
     Map<String, Object> initialValues = new HashMap<String, Object>(){{
-        put(Definitions.FIREBASE_ENABLED, true);
+        put(Definitions.FIREBASE_ENABLED, false);
         put(Definitions.NOTIFICATION_ID, 0);
         put(Definitions.NOTIFICATION_IMPORTANCE, NotificationImportance.Default);
         put(Definitions.NOTIFICATION_LAYOUT, NotificationLayout.Default);

--- a/example/lib/common_widgets/check_button.dart
+++ b/example/lib/common_widgets/check_button.dart
@@ -1,38 +1,39 @@
 import 'package:flutter/material.dart';
 
 class CheckButton extends StatelessWidget {
-
   final String label;
   final bool isSelected;
-  final Color labelColor;
-  final Color backgroundColor;
-  final void Function(bool) onPressed;
+  final void Function(bool)? onPressed;
 
-  const CheckButton(this.label, this.isSelected, {this.labelColor, this.backgroundColor, this.onPressed, Key key}) : super(key: key);
+  const CheckButton(
+    this.label,
+    this.isSelected, {
+    this.onPressed,
+    Key? key,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-
     MediaQueryData mediaQueryData = MediaQuery.of(context);
 
     return Padding(
-        padding: EdgeInsets.symmetric(vertical: 10, horizontal: 5),
-        child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-              Container(
-                  width: mediaQueryData.size.width - 110 /* 30 - 60 - 20 */,
-                  child: Text(label, style: TextStyle(fontSize: 16))
-              ),
-              Container(
-                  width: 60,
-                  child: Switch(
-                    value: isSelected,
-                    onChanged: onPressed,
-                  )
-              ),
-            ]
-        )
+      padding: EdgeInsets.symmetric(vertical: 10, horizontal: 5),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          Container(
+            width: mediaQueryData.size.width - 110 /* 30 - 60 - 20 */,
+            child: Text(label, style: TextStyle(fontSize: 16)),
+          ),
+          Container(
+            width: 60,
+            child: Switch(
+              value: isSelected,
+              onChanged: onPressed,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/example/lib/common_widgets/led_light.dart
+++ b/example/lib/common_widgets/led_light.dart
@@ -4,7 +4,7 @@ class LedLight extends StatelessWidget {
 
   final bool isOn;
 
-  const LedLight(this.isOn, {Key key}) : super(key: key);
+  const LedLight(this.isOn, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/common_widgets/remarkble_text.dart
+++ b/example/lib/common_widgets/remarkble_text.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 class RemarkableText extends StatelessWidget {
 
   final String text;
-  final Color color;
+  final Color? color;
 
-  const RemarkableText({Key key, this.text, this.color}) : super(key: key);
+  const RemarkableText({Key? key, required this.text, this.color}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/common_widgets/service_control_panel.dart
+++ b/example/lib/common_widgets/service_control_panel.dart
@@ -1,20 +1,23 @@
-
 import 'package:flutter/material.dart';
 import 'package:awesome_notifications_example/common_widgets/led_light.dart';
 import 'package:awesome_notifications_example/common_widgets/simple_button.dart';
 
 class ServiceControlPanel extends StatelessWidget {
-
   final String title;
   final bool statusControl;
   final ThemeData themeData;
-  final void Function() onPressed;
+  final void Function()? onPressed;
 
-  const ServiceControlPanel(this.title, this.statusControl, this.themeData, {Key key, this.onPressed}) : super(key: key);
+  const ServiceControlPanel(
+    this.title,
+    this.statusControl,
+    this.themeData, {
+    Key? key,
+    this.onPressed,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-
     MediaQueryData mediaQueryData = MediaQuery.of(context);
 
     return Container(
@@ -30,22 +33,21 @@ class ServiceControlPanel extends StatelessWidget {
                   text: '$title status:\n',
                   children: [
                     TextSpan(
-                        style: TextStyle(color: statusControl ? Colors.green : Colors.redAccent),
-                        text: (statusControl ? 'Available' : 'Unavailable')+'\n'
-                    ),
-                    WidgetSpan(
-                        child: LedLight(statusControl)
-                    )
-                  ]
-              ),
+                        style: TextStyle(
+                            color: statusControl
+                                ? Colors.green
+                                : Colors.redAccent),
+                        text: (statusControl ? 'Available' : 'Unavailable') +
+                            '\n'),
+                    WidgetSpan(child: LedLight(statusControl))
+                  ]),
             ),
           ),
-          SimpleButton(
-              'Go to $title\nTest Page',
+          SimpleButton('Go to $title\nTest Page',
               width: mediaQueryData.size.width * 0.4,
-              labelColor: statusControl ? themeData.hintColor : themeData.disabledColor,
-              onPressed: statusControl ? onPressed : null
-          ),
+              labelColor:
+                  statusControl ? themeData.hintColor : themeData.disabledColor,
+              onPressed: statusControl ? onPressed : null),
         ],
       ),
     );

--- a/example/lib/common_widgets/simple_button.dart
+++ b/example/lib/common_widgets/simple_button.dart
@@ -2,31 +2,38 @@ import 'package:flutter/material.dart';
 
 class SimpleButton extends StatelessWidget {
   final String label;
-  final Color labelColor;
-  final Color backgroundColor;
-  final double width;
-  final void Function() onPressed;
+  final Color? labelColor;
+  final Color? backgroundColor;
+  final double? width;
+  final void Function()? onPressed;
 
-  const SimpleButton(this.label, {Key key, this.labelColor, this.backgroundColor, this.width, this.onPressed}) : super(key: key);
+  const SimpleButton(
+    this.label, {
+    Key? key,
+    this.labelColor,
+    this.backgroundColor,
+    this.width,
+    this.onPressed,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Container(
-        width: width,
-        padding: EdgeInsets.symmetric(vertical: 5),
-        child: RaisedButton(
-          child: Padding(
-            padding: EdgeInsets.symmetric(vertical: 10, horizontal: 5),
-            child: Text(label, textAlign: TextAlign.center,
-              style: TextStyle(
-                  fontSize: 14
-              ),
-            ),
+      width: width,
+      padding: EdgeInsets.symmetric(vertical: 5),
+      child: RaisedButton(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 10, horizontal: 5),
+          child: Text(
+            label,
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 14),
           ),
-          color: backgroundColor,
-          textColor: labelColor,
-          onPressed: onPressed
-        )
+        ),
+        color: backgroundColor,
+        textColor: labelColor,
+        onPressed: onPressed,
+      ),
     );
   }
 }

--- a/example/lib/common_widgets/text_note.dart
+++ b/example/lib/common_widgets/text_note.dart
@@ -4,7 +4,7 @@ class TextNote extends StatelessWidget {
 
   final String text;
 
-  const TextNote(this.text, {Key key}) : super(key: key);
+  const TextNote(this.text, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/datasources/common/datasource.dart
+++ b/example/lib/datasources/common/datasource.dart
@@ -1,9 +1,13 @@
-
-
 import 'package:flutter/cupertino.dart';
 import 'package:http/http.dart';
 
 abstract class DataSource {
   @protected
-  Future<Response> fetchData({String directory, Map<String, String> parameters, Map<String, String> headers = const {}});
+  Future<Response?> fetchData({
+    String directory = '',
+    Map<String, String>? parameters,
+    Map<String, String> headers = const {},
+    String body = '',
+    int timeoutInMilliseconds = 5000,
+  });
 }

--- a/example/lib/datasources/common/http_datasource.dart
+++ b/example/lib/datasources/common/http_datasource.dart
@@ -10,8 +10,11 @@ class HttpDataSource extends DataSource {
   final bool isUsingHttps;
   final bool isCertificateHttps;
 
-  HttpDataSource(this.baseAPI,
-      {this.isUsingHttps = true, this.isCertificateHttps = true});
+  HttpDataSource({
+    required this.baseAPI,
+    this.isUsingHttps = true,
+    this.isCertificateHttps = true,
+  });
 
   String getDomainName() {
     return baseAPI;
@@ -22,21 +25,21 @@ class HttpDataSource extends DataSource {
   }
 
   void printDebugData(Response response) {
-    int sent;
-    int received = response.contentLength;
-    debugPrint('${response.request.method} (${response.statusCode}) - ' +
-        ((sent == null ? '' : 'Up:${fileSize(sent)} ') +
-            (received == null ? '' : 'Down:${fileSize(received)} ')) +
-        response.request.url.path);
+    int? sent = response.request?.contentLength;
+    int? received = response.contentLength;
+    debugPrint(
+      '${response.request?.method} (${response.statusCode}) - ${((sent == null ? '' : 'Up:${fileSize(sent)} ') + (received == null ? '' : 'Down:${fileSize(received)} '))}${response.request?.url.path}',
+    );
   }
 
   @override
-  Future<Response> fetchData(
-      {String directory = '',
-      Map<String, String> parameters,
-      Map<String, String> headers, // =
-      String body,
-      int timeoutInMilliseconds = 5000}) async {
+  Future<Response?> fetchData({
+    String directory = '',
+    Map<String, String>? parameters,
+    Map<String, String> headers = const {},
+    String body = '',
+    int timeoutInMilliseconds = 5000,
+  }) async {
     int tries = 3;
 
     do {
@@ -50,8 +53,8 @@ class HttpDataSource extends DataSource {
             ? Uri.https(baseAPI, directory, parameters)
             : Uri.http(baseAPI, directory, parameters);
         final Response response = body.isEmpty
-            ? await client.get(uri.toString(), headers: headers)
-            : await client.post(uri.toString(), headers: headers, body: body);
+            ? await client.get(uri, headers: headers)
+            : await client.post(uri, headers: headers, body: body);
 
         printDebugData(response);
         return response;

--- a/example/lib/datasources/firebase_datasource.dart
+++ b/example/lib/datasources/firebase_datasource.dart
@@ -1,95 +1,95 @@
-import 'dart:async';
-import 'dart:convert';
-import 'package:http/http.dart' show Response;
+// import 'dart:async';
+// import 'dart:convert';
+// import 'package:http/http.dart' show Response;
 
-import 'common/http_datasource.dart';
+// import 'common/http_datasource.dart';
 
-class FirebaseDataSource extends HttpDataSource {
+// class FirebaseDataSource extends HttpDataSource {
 
-  /// ************************************************************************************
-  ///
-  /// SINGLETON CONSTRUCTOR PATTERN
-  ///
-  /// ************************************************************************************
-  ///
-  static FirebaseDataSource _instance;
-  factory FirebaseDataSource({
-    String serverSecret
-  }) {
-    _instance ??= FirebaseDataSource._internalConstructor();
-    return _instance;
-  }
+//   /// ************************************************************************************
+//   ///
+//   /// SINGLETON CONSTRUCTOR PATTERN
+//   ///
+//   /// ************************************************************************************
+//   ///
+//   static FirebaseDataSource _instance;
+//   factory FirebaseDataSource({
+//     String serverSecret
+//   }) {
+//     _instance ??= FirebaseDataSource._internalConstructor();
+//     return _instance;
+//   }
 
-  FirebaseDataSource._internalConstructor()
-      : super(
-        'fcm.googleapis.com',
-        isUsingHttps: true,
-        isCertificateHttps: false
-      );
+//   FirebaseDataSource._internalConstructor()
+//       : super(
+//         'fcm.googleapis.com',
+//         isUsingHttps: true,
+//         isCertificateHttps: false
+//       );
 
-  /// ************************************************************************************
-  ///
-  /// FETCH DATA METHODS
-  ///
-  /// ************************************************************************************
+//   /// ************************************************************************************
+//   ///
+//   /// FETCH DATA METHODS
+//   ///
+//   /// ************************************************************************************
 
-  Future<String> _pushNotification({String firebaseServerKey, Map<String, dynamic> body = const {}}) async {
+//   Future<String> _pushNotification({String firebaseServerKey, Map<String, dynamic> body = const {}}) async {
 
-    if((firebaseServerKey ?? '').isEmpty){
-      return 'Server Key not defined';
-    }
+//     if((firebaseServerKey ?? '').isEmpty){
+//       return 'Server Key not defined';
+//     }
 
-    Response response = await fetchData(
-        directory: '/fcm/send',
-        headers: {
-          'Authorization': 'key=$firebaseServerKey',
-          'Content-Type': 'application/json'
-        },
-        body: jsonEncode(body)
-    );
+//     Response response = await fetchData(
+//         directory: '/fcm/send',
+//         headers: {
+//           'Authorization': 'key=$firebaseServerKey',
+//           'Content-Type': 'application/json'
+//         },
+//         body: jsonEncode(body)
+//     );
 
-    if(response.statusCode == 200){
-      return response.bodyBytes.toString();
-    }
+//     if(response.statusCode == 200){
+//       return response.bodyBytes.toString();
+//     }
 
-    return '';
-  }
+//     return '';
+//   }
 
-  Future<String> pushBasicNotification({
-    String firebaseServerKey,
-    String firebaseAppToken,
-    int notificationId,
-    String title,
-    String body,
-    Map<String, String> payload = const {}
-  }) async {
+//   Future<String> pushBasicNotification({
+//     String firebaseServerKey,
+//     String firebaseAppToken,
+//     int notificationId,
+//     String title,
+//     String body,
+//     Map<String, String> payload = const {}
+//   }) async {
 
-    return await _pushNotification(
-        firebaseServerKey: firebaseServerKey,
-        body: getFirebaseExampleContent(firebaseAppToken: firebaseAppToken)
-    );
-  }
+//     return await _pushNotification(
+//         firebaseServerKey: firebaseServerKey,
+//         body: getFirebaseExampleContent(firebaseAppToken: firebaseAppToken)
+//     );
+//   }
 
-  Map<String, dynamic> getFirebaseExampleContent({
-    String firebaseAppToken
-  }){
-    return {
-      'collapse_key': 'type_a',
-      'to': firebaseAppToken,
-      'data': {
-        "content": {
-          "id": 100,
-          "channelKey": "big_picture",
-          "title": "Huston!\nThe eagle has landed!",
-          "body": "A small step for a man, but a giant leap to Flutter's community!",
-          "notificationLayout": "BigPicture",
-          "largeIcon": "https://avidabloga.files.wordpress.com/2012/08/emmemc3b3riadeneilarmstrong3.jpg",
-          "bigPicture": "https://www.dw.com/image/49519617_303.jpg",
-          "showWhen": true,
-          "autoCancel": true,
-          "privacy": "Private"
-        }
-      }
-    };
-  }
-}
+//   Map<String, dynamic> getFirebaseExampleContent({
+//     String firebaseAppToken
+//   }){
+//     return {
+//       'collapse_key': 'type_a',
+//       'to': firebaseAppToken,
+//       'data': {
+//         "content": {
+//           "id": 100,
+//           "channelKey": "big_picture",
+//           "title": "Huston!\nThe eagle has landed!",
+//           "body": "A small step for a man, but a giant leap to Flutter's community!",
+//           "notificationLayout": "BigPicture",
+//           "largeIcon": "https://avidabloga.files.wordpress.com/2012/08/emmemc3b3riadeneilarmstrong3.jpg",
+//           "bigPicture": "https://www.dw.com/image/49519617_303.jpg",
+//           "showWhen": true,
+//           "autoCancel": true,
+//           "privacy": "Private"
+//         }
+//       }
+//     };
+//   }
+// }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,168 +5,150 @@ import 'package:awesome_notifications_example/models/media_model.dart';
 import 'package:awesome_notifications_example/utils/media_player_central.dart';
 
 void main() async {
-
-  AwesomeNotifications().initialize(
-    'resource://drawable/res_app_icon',
-    [
-      NotificationChannel(
-          channelKey: 'basic_channel',
-          channelName: 'Basic notifications',
-          channelDescription: 'Notification channel for basic tests',
-          defaultColor: Color(0xFF9D50DD),
-          ledColor: Colors.white
-      ),
-      NotificationChannel(
-          channelKey: 'badge_channel',
-          channelName: 'Badge indicator notifications',
-          channelDescription: 'Notification channel to activate badge indicator',
-          channelShowBadge: true,
-          defaultColor: Color(0xFF9D50DD),
-          ledColor: Colors.yellow
-      ),
-      NotificationChannel(
-          channelKey: 'ringtone_channel',
-          channelName: 'Ringtone Channel',
-          channelDescription: 'Channel with default ringtone',
-          defaultColor: Color(0xFF9D50DD),
-          ledColor: Colors.white,
-          defaultRingtoneType: DefaultRingtoneType.Ringtone
-      ),
-      NotificationChannel(
-          channelKey: 'updated_channel',
-          channelName: 'Channel to update',
-          channelDescription: 'Notifications with not updated channel',
-          defaultColor: Color(0xFF9D50DD),
-          ledColor: Colors.white
-      ),
-      NotificationChannel(
-          channelKey: 'low_intensity',
-          channelName: 'Low intensity notifications',
-          channelDescription: 'Notification channel for notifications with low intensity',
-          defaultColor: Colors.green,
-          ledColor: Colors.green,
-          vibrationPattern: lowVibrationPattern
-      ),
-      NotificationChannel(
-          channelKey: 'medium_intensity',
-          channelName: 'Medium intensity notifications',
-          channelDescription: 'Notification channel for notifications with medium intensity',
-          defaultColor: Colors.yellow,
-          ledColor: Colors.yellow,
-          vibrationPattern: mediumVibrationPattern
-      ),
-      NotificationChannel(
-          channelKey: 'high_intensity',
-          channelName: 'High intensity notifications',
-          channelDescription: 'Notification channel for notifications with high intensity',
-          defaultColor: Colors.red,
-          ledColor: Colors.red,
-          vibrationPattern: highVibrationPattern
-      ),
-      NotificationChannel(
-          channelKey: "private_channel",
-          channelName: "Privates notification channel",
-          channelDescription: "Privates notification from lock screen",
-          playSound: true,
-          defaultColor: Colors.red,
-          ledColor: Colors.red,
-          vibrationPattern: lowVibrationPattern,
-          defaultPrivacy: NotificationPrivacy.Private
-      ),
-      NotificationChannel(
-          icon: 'resource://drawable/res_power_ranger_thunder',
-          channelKey: "custom_sound",
-          channelName: "Custom sound notifications",
-          channelDescription: "Notifications with custom sound",
-          playSound: true,
-          soundSource: 'resource://raw/res_morph_power_rangers',
-          defaultColor: Colors.red,
-          ledColor: Colors.red,
-          vibrationPattern: lowVibrationPattern
-      ),
-      NotificationChannel(
-          channelKey: "silenced",
-          channelName: "Silenced notifications",
-          channelDescription: "The most quiet notifications",
-          playSound: false,
-          enableVibration: false,
-          enableLights: false
-      ),
-      NotificationChannel(
-        icon: 'resource://drawable/res_media_icon',
-        channelKey: 'media_player',
-        channelName: 'Media player controller',
-        channelDescription: 'Media player controller',
-        defaultPrivacy: NotificationPrivacy.Public,
-        enableVibration: false,
-        enableLights: false,
+  AwesomeNotifications().initialize('resource://drawable/res_app_icon', [
+    NotificationChannel(
+        channelKey: 'basic_channel',
+        channelName: 'Basic notifications',
+        channelDescription: 'Notification channel for basic tests',
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Colors.white),
+    NotificationChannel(
+        channelKey: 'badge_channel',
+        channelName: 'Badge indicator notifications',
+        channelDescription: 'Notification channel to activate badge indicator',
+        channelShowBadge: true,
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Colors.yellow),
+    NotificationChannel(
+        channelKey: 'ringtone_channel',
+        channelName: 'Ringtone Channel',
+        channelDescription: 'Channel with default ringtone',
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Colors.white,
+        defaultRingtoneType: DefaultRingtoneType.Ringtone),
+    NotificationChannel(
+        channelKey: 'updated_channel',
+        channelName: 'Channel to update',
+        channelDescription: 'Notifications with not updated channel',
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Colors.white),
+    NotificationChannel(
+        channelKey: 'low_intensity',
+        channelName: 'Low intensity notifications',
+        channelDescription:
+            'Notification channel for notifications with low intensity',
+        defaultColor: Colors.green,
+        ledColor: Colors.green,
+        vibrationPattern: lowVibrationPattern),
+    NotificationChannel(
+        channelKey: 'medium_intensity',
+        channelName: 'Medium intensity notifications',
+        channelDescription:
+            'Notification channel for notifications with medium intensity',
+        defaultColor: Colors.yellow,
+        ledColor: Colors.yellow,
+        vibrationPattern: mediumVibrationPattern),
+    NotificationChannel(
+        channelKey: 'high_intensity',
+        channelName: 'High intensity notifications',
+        channelDescription:
+            'Notification channel for notifications with high intensity',
+        defaultColor: Colors.red,
+        ledColor: Colors.red,
+        vibrationPattern: highVibrationPattern),
+    NotificationChannel(
+        channelKey: "private_channel",
+        channelName: "Privates notification channel",
+        channelDescription: "Privates notification from lock screen",
+        playSound: true,
+        defaultColor: Colors.red,
+        ledColor: Colors.red,
+        vibrationPattern: lowVibrationPattern,
+        defaultPrivacy: NotificationPrivacy.Private),
+    NotificationChannel(
+        icon: 'resource://drawable/res_power_ranger_thunder',
+        channelKey: "custom_sound",
+        channelName: "Custom sound notifications",
+        channelDescription: "Notifications with custom sound",
+        playSound: true,
+        soundSource: 'resource://raw/res_morph_power_rangers',
+        defaultColor: Colors.red,
+        ledColor: Colors.red,
+        vibrationPattern: lowVibrationPattern),
+    NotificationChannel(
+        channelKey: "silenced",
+        channelName: "Silenced notifications",
+        channelDescription: "The most quiet notifications",
         playSound: false,
-        locked: true,
-      ),
-      NotificationChannel(
-          channelKey: 'big_picture',
-          channelName: 'Big pictures',
-          channelDescription: 'Notifications with big and beautiful images',
-          defaultColor: Color(0xFF9D50DD),
-          ledColor: Color(0xFF9D50DD),
-          vibrationPattern: lowVibrationPattern
-      ),
-      NotificationChannel(
-          channelKey: 'big_text',
-          channelName: 'Big text notifications',
-          channelDescription: 'Notifications with a expandable body text',
-          defaultColor: Colors.blueGrey,
-          ledColor: Colors.blueGrey,
-          vibrationPattern: lowVibrationPattern
-      ),
-      NotificationChannel(
-          channelKey: 'inbox',
-          channelName: 'Inbox notifications',
-          channelDescription: 'Notifications with inbox layout',
-          defaultColor: Color(0xFF9D50DD),
-          ledColor: Color(0xFF9D50DD),
-          vibrationPattern: mediumVibrationPattern
-      ),
-      NotificationChannel(
-          channelKey: 'scheduled',
-          channelName: 'Scheduled notifications',
-          channelDescription: 'Notifications with schedule functionality',
-          defaultColor: Color(0xFF9D50DD),
-          ledColor: Color(0xFF9D50DD),
-          vibrationPattern: lowVibrationPattern,
-          importance: NotificationImportance.High,
-          defaultRingtoneType: DefaultRingtoneType.Alarm
-      ),
-      NotificationChannel(
-          icon: 'resource://drawable/res_download_icon',
-          channelKey: 'progress_bar',
-          channelName: 'Progress bar notifications',
-          channelDescription: 'Notifications with a progress bar layout',
-          defaultColor: Colors.deepPurple,
-          ledColor: Colors.deepPurple,
-          vibrationPattern: lowVibrationPattern,
-          onlyAlertOnce: true
-      ),
-      NotificationChannel(
-          channelKey: 'grouped',
-          channelName: 'Grouped notifications',
-          channelDescription: 'Notifications with group functionality',
-          groupKey: 'grouped',
-          groupSort: GroupSort.Desc,
-          groupAlertBehavior: GroupAlertBehavior.Children,
-          defaultColor: Colors.lightGreen,
-          ledColor: Colors.lightGreen,
-          vibrationPattern: lowVibrationPattern,
-          importance: NotificationImportance.High
-      )
-    ]
-  );
+        enableVibration: false,
+        enableLights: false),
+    NotificationChannel(
+      icon: 'resource://drawable/res_media_icon',
+      channelKey: 'media_player',
+      channelName: 'Media player controller',
+      channelDescription: 'Media player controller',
+      defaultPrivacy: NotificationPrivacy.Public,
+      enableVibration: false,
+      enableLights: false,
+      playSound: false,
+      locked: true,
+    ),
+    NotificationChannel(
+        channelKey: 'big_picture',
+        channelName: 'Big pictures',
+        channelDescription: 'Notifications with big and beautiful images',
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Color(0xFF9D50DD),
+        vibrationPattern: lowVibrationPattern),
+    NotificationChannel(
+        channelKey: 'big_text',
+        channelName: 'Big text notifications',
+        channelDescription: 'Notifications with a expandable body text',
+        defaultColor: Colors.blueGrey,
+        ledColor: Colors.blueGrey,
+        vibrationPattern: lowVibrationPattern),
+    NotificationChannel(
+        channelKey: 'inbox',
+        channelName: 'Inbox notifications',
+        channelDescription: 'Notifications with inbox layout',
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Color(0xFF9D50DD),
+        vibrationPattern: mediumVibrationPattern),
+    NotificationChannel(
+        channelKey: 'scheduled',
+        channelName: 'Scheduled notifications',
+        channelDescription: 'Notifications with schedule functionality',
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Color(0xFF9D50DD),
+        vibrationPattern: lowVibrationPattern,
+        importance: NotificationImportance.High,
+        defaultRingtoneType: DefaultRingtoneType.Alarm),
+    NotificationChannel(
+        icon: 'resource://drawable/res_download_icon',
+        channelKey: 'progress_bar',
+        channelName: 'Progress bar notifications',
+        channelDescription: 'Notifications with a progress bar layout',
+        defaultColor: Colors.deepPurple,
+        ledColor: Colors.deepPurple,
+        vibrationPattern: lowVibrationPattern,
+        onlyAlertOnce: true),
+    NotificationChannel(
+        channelKey: 'grouped',
+        channelName: 'Grouped notifications',
+        channelDescription: 'Notifications with group functionality',
+        groupKey: 'grouped',
+        groupSort: GroupSort.Desc,
+        groupAlertBehavior: GroupAlertBehavior.Children,
+        defaultColor: Colors.lightGreen,
+        ledColor: Colors.lightGreen,
+        vibrationPattern: lowVibrationPattern,
+        importance: NotificationImportance.High)
+  ]);
 
   runApp(App());
 }
 
 class App extends StatefulWidget {
-
   static final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
 
   static String name = 'Push Notifications - Example App';
@@ -177,17 +159,45 @@ class App extends StatefulWidget {
 }
 
 class _AppState extends State<App> {
-
   @override
   void initState() {
-
     MediaPlayerCentral.addAll([
-      MediaModel(diskImagePath: 'asset://assets/images/rock-disc.jpg',    colorCaptureSize: Size(788,800), bandName: 'Bright Sharp',   trackName: 'Champagne Supernova', trackSize: Duration(minutes: 4, seconds: 21)),
-      MediaModel(diskImagePath: 'asset://assets/images/classic-disc.jpg', colorCaptureSize: Size(500,500), bandName: 'Best of Mozart', trackName: 'Allegro', trackSize: Duration(minutes: 7, seconds: 41)),
-      MediaModel(diskImagePath: 'asset://assets/images/remix-disc.jpg',   colorCaptureSize: Size(500,500), bandName: 'Dj Allucard',    trackName: '21st Century', trackSize: Duration(minutes: 4, seconds: 59)),
-      MediaModel(diskImagePath: 'asset://assets/images/dj-disc.jpg',      colorCaptureSize: Size(500,500), bandName: 'Dj Brainiak',    trackName: 'Speed of light', trackSize: Duration(minutes: 4, seconds: 59)),
-      MediaModel(diskImagePath: 'asset://assets/images/80s-disc.jpg',     colorCaptureSize: Size(500,500), bandName: 'Back to the 80\'s',    trackName: 'Disco revenge', trackSize: Duration(minutes: 4, seconds: 59)),
-      MediaModel(diskImagePath: 'asset://assets/images/old-disc.jpg',     colorCaptureSize: Size(500,500), bandName: 'PeacefulMind',  trackName: 'Never look at back', trackSize: Duration(minutes: 4, seconds: 59)),
+      MediaModel(
+          diskImagePath: 'asset://assets/images/rock-disc.jpg',
+          colorCaptureSize: Size(788, 800),
+          bandName: 'Bright Sharp',
+          trackName: 'Champagne Supernova',
+          trackSize: Duration(minutes: 4, seconds: 21)),
+      MediaModel(
+          diskImagePath: 'asset://assets/images/classic-disc.jpg',
+          colorCaptureSize: Size(500, 500),
+          bandName: 'Best of Mozart',
+          trackName: 'Allegro',
+          trackSize: Duration(minutes: 7, seconds: 41)),
+      MediaModel(
+          diskImagePath: 'asset://assets/images/remix-disc.jpg',
+          colorCaptureSize: Size(500, 500),
+          bandName: 'Dj Allucard',
+          trackName: '21st Century',
+          trackSize: Duration(minutes: 4, seconds: 59)),
+      MediaModel(
+          diskImagePath: 'asset://assets/images/dj-disc.jpg',
+          colorCaptureSize: Size(500, 500),
+          bandName: 'Dj Brainiak',
+          trackName: 'Speed of light',
+          trackSize: Duration(minutes: 4, seconds: 59)),
+      MediaModel(
+          diskImagePath: 'asset://assets/images/80s-disc.jpg',
+          colorCaptureSize: Size(500, 500),
+          bandName: 'Back to the 80\'s',
+          trackName: 'Disco revenge',
+          trackSize: Duration(minutes: 4, seconds: 59)),
+      MediaModel(
+          diskImagePath: 'asset://assets/images/old-disc.jpg',
+          colorCaptureSize: Size(500, 500),
+          bandName: 'PeacefulMind',
+          trackName: 'Never look at back',
+          trackSize: Duration(minutes: 4, seconds: 59)),
     ]);
 
     super.initState();
@@ -195,71 +205,74 @@ class _AppState extends State<App> {
 
   @override
   Widget build(BuildContext context) {
-
     return MaterialApp(
-        navigatorKey: App.navKey,
-        title: App.name,
-        color: App.mainColor,
-        initialRoute: PAGE_HOME,
-        //onGenerateRoute: generateRoute,
-        routes: materialRoutes,
-        builder: (context, child) =>
-            MediaQuery(data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true), child: child),
-        theme: ThemeData(
+      navigatorKey: App.navKey,
+      title: App.name,
+      color: App.mainColor,
+      initialRoute: PAGE_HOME,
+      //onGenerateRoute: generateRoute,
+      routes: materialRoutes,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),
+        child: child ?? const SizedBox.shrink(),
+      ),
+      theme: ThemeData(
+        brightness: Brightness.light,
 
-          brightness: Brightness.light,
+        primaryColor: App.mainColor,
+        accentColor: Colors.blueGrey,
+        primarySwatch: Colors.blueGrey,
+        canvasColor: Colors.white,
+        focusColor: Colors.blueAccent,
+        disabledColor: Colors.grey,
 
-          primaryColor:   App.mainColor,
-          accentColor:    Colors.blueGrey,
-          primarySwatch:  Colors.blueGrey,
-          canvasColor:    Colors.white,
-          focusColor:     Colors.blueAccent,
-          disabledColor:  Colors.grey,
+        backgroundColor: Colors.blueGrey.shade400,
 
-          backgroundColor: Colors.blueGrey.shade400,
-
-          appBarTheme: AppBarTheme(
-              brightness: Brightness.dark,
-              color: Colors.white,
-              elevation: 0,
-              iconTheme: IconThemeData(
-                color: App.mainColor,
-              ),
-              textTheme: TextTheme(
-                headline6: TextStyle(color: App.mainColor, fontSize: 18),
-              )
-          ),
-
-          fontFamily: 'Robot',
-
-          // Define the default TextTheme. Use this to specify the default
-          // text styling for headlines, titles, bodies of text, and more.
-          textTheme: TextTheme(
-              headline1: TextStyle(fontSize: 64.0, height: 1.5, fontWeight: FontWeight.w500),
-              headline2: TextStyle(fontSize: 52.0, height: 1.5, fontWeight: FontWeight.w500),
-              headline3: TextStyle(fontSize: 48.0, height: 1.5, fontWeight: FontWeight.w500),
-              headline4: TextStyle(fontSize: 32.0, height: 1.5, fontWeight: FontWeight.w500),
-              headline5: TextStyle(fontSize: 28.0, height: 1.5, fontWeight: FontWeight.w500),
-              headline6: TextStyle(fontSize: 22.0, height: 1.5, fontWeight: FontWeight.w500),
-              subtitle1: TextStyle(fontSize: 18.0, height: 1.5, color: Colors.black54),
-              subtitle2: TextStyle(fontSize: 12.0, height: 1.5, color: Colors.black54),
-              button:    TextStyle(fontSize: 16.0, height: 1.5, color: Colors.black54),
-              bodyText1: TextStyle(fontSize: 16.0, height: 1.5),
-              bodyText2: TextStyle(fontSize: 16.0, height: 1.5),
-          ),
-
-          buttonTheme: ButtonThemeData(
-            buttonColor: Colors.grey.shade200,
-            shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.all(Radius.circular(5))
+        appBarTheme: AppBarTheme(
+            brightness: Brightness.dark,
+            color: Colors.white,
+            elevation: 0,
+            iconTheme: IconThemeData(
+              color: App.mainColor,
             ),
-            padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 15.0),
-            textTheme: ButtonTextTheme.accent,
-          ),
+            textTheme: TextTheme(
+              headline6: TextStyle(color: App.mainColor, fontSize: 18),
+            )),
+
+        fontFamily: 'Robot',
+
+        // Define the default TextTheme. Use this to specify the default
+        // text styling for headlines, titles, bodies of text, and more.
+        textTheme: TextTheme(
+          headline1: TextStyle(
+              fontSize: 64.0, height: 1.5, fontWeight: FontWeight.w500),
+          headline2: TextStyle(
+              fontSize: 52.0, height: 1.5, fontWeight: FontWeight.w500),
+          headline3: TextStyle(
+              fontSize: 48.0, height: 1.5, fontWeight: FontWeight.w500),
+          headline4: TextStyle(
+              fontSize: 32.0, height: 1.5, fontWeight: FontWeight.w500),
+          headline5: TextStyle(
+              fontSize: 28.0, height: 1.5, fontWeight: FontWeight.w500),
+          headline6: TextStyle(
+              fontSize: 22.0, height: 1.5, fontWeight: FontWeight.w500),
+          subtitle1:
+              TextStyle(fontSize: 18.0, height: 1.5, color: Colors.black54),
+          subtitle2:
+              TextStyle(fontSize: 12.0, height: 1.5, color: Colors.black54),
+          button: TextStyle(fontSize: 16.0, height: 1.5, color: Colors.black54),
+          bodyText1: TextStyle(fontSize: 16.0, height: 1.5),
+          bodyText2: TextStyle(fontSize: 16.0, height: 1.5),
         ),
+
+        buttonTheme: ButtonThemeData(
+          buttonColor: Colors.grey.shade200,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(5))),
+          padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 15.0),
+          textTheme: ButtonTextTheme.accent,
+        ),
+      ),
     );
   }
 }
-
-
-

--- a/example/lib/models/media_model.dart
+++ b/example/lib/models/media_model.dart
@@ -8,11 +8,7 @@ class CloseCaptionElement {
   Duration end;
   String subtitle;
 
-  CloseCaptionElement(
-    this.start,
-    this.end,
-    this.subtitle
-  );
+  CloseCaptionElement(this.start, this.end, this.subtitle);
 }
 
 class MediaModel {
@@ -27,31 +23,49 @@ class MediaModel {
   final Size colorCaptureSize;
 
   final List<CloseCaptionElement> closeCaption = [
-    CloseCaptionElement(Duration(minutes: 0, seconds: 15), Duration(minutes: 0, seconds: 20), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 0, seconds: 30), Duration(minutes: 0, seconds: 35), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 0, seconds: 45), Duration(minutes: 0, seconds: 50), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 1, seconds: 00), Duration(minutes: 1, seconds: 05), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 1, seconds: 15), Duration(minutes: 1, seconds: 20), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 1, seconds: 30), Duration(minutes: 1, seconds: 35), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 1, seconds: 45), Duration(minutes: 1, seconds: 50), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 2, seconds: 00), Duration(minutes: 2, seconds: 05), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 2, seconds: 15), Duration(minutes: 2, seconds: 20), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 2, seconds: 30), Duration(minutes: 2, seconds: 35), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 2, seconds: 45), Duration(minutes: 2, seconds: 50), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 3, seconds: 00), Duration(minutes: 3, seconds: 05), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 3, seconds: 15), Duration(minutes: 3, seconds: 20), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 3, seconds: 30), Duration(minutes: 3, seconds: 35), 'la la la la la la'),
-    CloseCaptionElement(Duration(minutes: 3, seconds: 45), Duration(minutes: 3, seconds: 50), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 0, seconds: 15),
+        Duration(minutes: 0, seconds: 20), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 0, seconds: 30),
+        Duration(minutes: 0, seconds: 35), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 0, seconds: 45),
+        Duration(minutes: 0, seconds: 50), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 1, seconds: 00),
+        Duration(minutes: 1, seconds: 05), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 1, seconds: 15),
+        Duration(minutes: 1, seconds: 20), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 1, seconds: 30),
+        Duration(minutes: 1, seconds: 35), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 1, seconds: 45),
+        Duration(minutes: 1, seconds: 50), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 2, seconds: 00),
+        Duration(minutes: 2, seconds: 05), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 2, seconds: 15),
+        Duration(minutes: 2, seconds: 20), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 2, seconds: 30),
+        Duration(minutes: 2, seconds: 35), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 2, seconds: 45),
+        Duration(minutes: 2, seconds: 50), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 3, seconds: 00),
+        Duration(minutes: 3, seconds: 05), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 3, seconds: 15),
+        Duration(minutes: 3, seconds: 20), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 3, seconds: 30),
+        Duration(minutes: 3, seconds: 35), 'la la la la la la'),
+    CloseCaptionElement(Duration(minutes: 3, seconds: 45),
+        Duration(minutes: 3, seconds: 50), 'la la la la la la'),
   ];
 
-  MediaModel({String diskImagePath, this.bandName, this.trackName, this.trackSize, this.colorCaptureSize = const Size(50.0, 50.0)}){
-    assert(!StringUtils.isNullOrEmpty(diskImagePath));
-    assert(!StringUtils.isNullOrEmpty(bandName));
-    assert(!StringUtils.isNullOrEmpty(trackName));
-
-    _diskImagePath = diskImagePath;
-    isPlaying = false;
-  }
+  MediaModel({
+    required String diskImagePath,
+    required this.bandName,
+    required this.trackName,
+    required this.trackSize,
+    this.colorCaptureSize = const Size(50.0, 50.0),
+  })  : assert(diskImagePath.isNotEmpty),
+        assert(bandName.isNotEmpty),
+        assert(trackName.isNotEmpty),
+        _diskImagePath = diskImagePath,
+        isPlaying = false;
 
   ImageProvider get diskImage => BitmapUtils().getFromMediaPath(_diskImagePath);
   String get diskImagePath => _diskImagePath;

--- a/example/lib/pages/firebase_test_page.dart
+++ b/example/lib/pages/firebase_test_page.dart
@@ -1,159 +1,159 @@
 
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+// import 'package:flutter/material.dart';
+// import 'package:flutter/services.dart';
 
-import 'package:fluttertoast/fluttertoast.dart';
-import 'package:awesome_notifications/awesome_notifications.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+// import 'package:fluttertoast/fluttertoast.dart';
+// import 'package:awesome_notifications/awesome_notifications.dart';
+// import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:awesome_notifications_example/common_widgets/simple_button.dart';
-import 'package:awesome_notifications_example/datasources/firebase_datasource.dart';
-import 'package:awesome_notifications_example/main.dart';
+// import 'package:awesome_notifications_example/common_widgets/simple_button.dart';
+// import 'package:awesome_notifications_example/datasources/firebase_datasource.dart';
+// import 'package:awesome_notifications_example/main.dart';
 
-class FirebaseTestPage extends StatefulWidget {
+// class FirebaseTestPage extends StatefulWidget {
 
-  final String firebaseAppToken;
-  final String packageName = 'me.carda.awesome_notifications_example';
-  final String sharedLastKeyReference = 'FcmServerKey';
+//   final String firebaseAppToken;
+//   final String packageName = 'me.carda.awesome_notifications_example';
+//   final String sharedLastKeyReference = 'FcmServerKey';
 
-  FirebaseTestPage(this.firebaseAppToken);
+//   FirebaseTestPage(this.firebaseAppToken);
 
-  final FirebaseDataSource firebaseDataSource = FirebaseDataSource();
+//   final FirebaseDataSource firebaseDataSource = FirebaseDataSource();
 
-  @override
-  _FirebaseTestPageState createState() => _FirebaseTestPageState();
+//   @override
+//   _FirebaseTestPageState createState() => _FirebaseTestPageState();
 
-}
+// }
 
-class _FirebaseTestPageState extends State<FirebaseTestPage> {
+// class _FirebaseTestPageState extends State<FirebaseTestPage> {
 
-  final _formKey = GlobalKey<FormState>();
-  TextEditingController _serverKeyTextController;
+//   final _formKey = GlobalKey<FormState>();
+//   TextEditingController _serverKeyTextController;
 
-  @override
-  void initState() {
-    super.initState();
-  }
+//   @override
+//   void initState() {
+//     super.initState();
+//   }
 
-  String serverKeyValidation(value){
-    if (value.isEmpty) {
-      return 'The FCM server key is required';
-    }
+//   String serverKeyValidation(value){
+//     if (value.isEmpty) {
+//       return 'The FCM server key is required';
+//     }
 
-    if (!RegExp(r'^[A-z0-9\:\-\_]{150,}$').hasMatch(value)) {
-      return 'Enter Valid FCM server key';
-    }
+//     if (!RegExp(r'^[A-z0-9\:\-\_]{150,}$').hasMatch(value)) {
+//       return 'Enter Valid FCM server key';
+//     }
 
-    return null;
-  }
+//     return null;
+//   }
 
-  Future<String> getLastServerKey() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    return prefs.getString(widget.sharedLastKeyReference) ?? '';
-  }
+//   Future<String> getLastServerKey() async {
+//     SharedPreferences prefs = await SharedPreferences.getInstance();
+//     return prefs.getString(widget.sharedLastKeyReference) ?? '';
+//   }
 
-  @override
-  Widget build(BuildContext context) {
+//   @override
+//   Widget build(BuildContext context) {
 
 
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: Text('Firebase Push Test', style: TextStyle(fontSize: 20)),
-        elevation: 10,
-      ),
-      body: FutureBuilder<String>(
-          future: getLastServerKey(),
-          builder: (context, AsyncSnapshot<String> snapshot) {
-            if (!snapshot.hasData) {
-              return Center(child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(App.mainColor), ));
-            } else {
-              String lastServerKey = snapshot.data;
-              _serverKeyTextController = TextEditingController(text: lastServerKey);
-              return ListView(
-                padding: EdgeInsets.symmetric( horizontal: 15, vertical:20 ),
-                children: <Widget>[
-                  Text('Firebase App Token:'),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical:15.0),
-                    child: Text(widget.firebaseAppToken, style: TextStyle(color: App.mainColor)),
-                  ),
-                  SimpleButton(
-                    'Copy Firebase app token',
-                    onPressed: () async {
-                      if(widget.firebaseAppToken.isNotEmpty){
-                        Clipboard.setData(ClipboardData(text: widget.firebaseAppToken));
-                        Fluttertoast.showToast(msg: 'Token copied');
-                      }
-                    },
-                  ),
-                  SizedBox(height: 30),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 20.0),
-                    child: Form(
-                      key: _formKey,
-                      autovalidate: false,
-                      child: Column(
-                        children: <Widget>[
-                          TextFormField(
-                            minLines: 1,//Normal textInputField will be displayed
-                            maxLines: 5,// when user presses enter it will adapt to it
-                            keyboardType: TextInputType.multiline,
-                            controller: _serverKeyTextController,
-                            validator: serverKeyValidation,
-                            decoration: InputDecoration(
-                                border: OutlineInputBorder(),
-                                prefixIcon: Icon(Icons.lock),
-                                labelText: ' Firebase Server Key ',
-                                hintText: 'Paste here your Firebase server Key'
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  Text(
-                      MapUtils.printPrettyMap(
-                          widget.firebaseDataSource.getFirebaseExampleContent(firebaseAppToken: _serverKeyTextController.value.text)
-                      )
-                  ),
-                  SimpleButton(
-                    'Send Firebase request',
-                    onPressed: () async {
-                      String fcmServerKey = _serverKeyTextController.value.text;
-                      SharedPreferences prefs = await SharedPreferences.getInstance();
-                      prefs.setString(widget.sharedLastKeyReference, fcmServerKey);
+//     return Scaffold(
+//       appBar: AppBar(
+//         centerTitle: true,
+//         title: Text('Firebase Push Test', style: TextStyle(fontSize: 20)),
+//         elevation: 10,
+//       ),
+//       body: FutureBuilder<String>(
+//           future: getLastServerKey(),
+//           builder: (context, AsyncSnapshot<String> snapshot) {
+//             if (!snapshot.hasData) {
+//               return Center(child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(App.mainColor), ));
+//             } else {
+//               String lastServerKey = snapshot.data;
+//               _serverKeyTextController = TextEditingController(text: lastServerKey);
+//               return ListView(
+//                 padding: EdgeInsets.symmetric( horizontal: 15, vertical:20 ),
+//                 children: <Widget>[
+//                   Text('Firebase App Token:'),
+//                   Padding(
+//                     padding: const EdgeInsets.symmetric(vertical:15.0),
+//                     child: Text(widget.firebaseAppToken, style: TextStyle(color: App.mainColor)),
+//                   ),
+//                   SimpleButton(
+//                     'Copy Firebase app token',
+//                     onPressed: () async {
+//                       if(widget.firebaseAppToken.isNotEmpty){
+//                         Clipboard.setData(ClipboardData(text: widget.firebaseAppToken));
+//                         Fluttertoast.showToast(msg: 'Token copied');
+//                       }
+//                     },
+//                   ),
+//                   SizedBox(height: 30),
+//                   Padding(
+//                     padding: const EdgeInsets.symmetric(vertical: 20.0),
+//                     child: Form(
+//                       key: _formKey,
+//                       autovalidate: false,
+//                       child: Column(
+//                         children: <Widget>[
+//                           TextFormField(
+//                             minLines: 1,//Normal textInputField will be displayed
+//                             maxLines: 5,// when user presses enter it will adapt to it
+//                             keyboardType: TextInputType.multiline,
+//                             controller: _serverKeyTextController,
+//                             validator: serverKeyValidation,
+//                             decoration: InputDecoration(
+//                                 border: OutlineInputBorder(),
+//                                 prefixIcon: Icon(Icons.lock),
+//                                 labelText: ' Firebase Server Key ',
+//                                 hintText: 'Paste here your Firebase server Key'
+//                             ),
+//                           )
+//                         ],
+//                       ),
+//                     ),
+//                   ),
+//                   Text(
+//                       MapUtils.printPrettyMap(
+//                           widget.firebaseDataSource.getFirebaseExampleContent(firebaseAppToken: _serverKeyTextController.value.text)
+//                       )
+//                   ),
+//                   SimpleButton(
+//                     'Send Firebase request',
+//                     onPressed: () async {
+//                       String fcmServerKey = _serverKeyTextController.value.text;
+//                       SharedPreferences prefs = await SharedPreferences.getInstance();
+//                       prefs.setString(widget.sharedLastKeyReference, fcmServerKey);
 
-                      if(_formKey.currentState.validate()){
+//                       if(_formKey.currentState.validate()){
 
-                        FocusScopeNode currentFocus = FocusScope.of(context);
-                        if (!currentFocus.hasPrimaryFocus) {
-                          currentFocus.unfocus();
-                        }
+//                         FocusScopeNode currentFocus = FocusScope.of(context);
+//                         if (!currentFocus.hasPrimaryFocus) {
+//                           currentFocus.unfocus();
+//                         }
 
-                        pushFirebaseNotification(1, fcmServerKey);
-                      }
-                    },
-                  )
-                ]
-            );
-          }
-        },
-      )
-    );
-  }
+//                         pushFirebaseNotification(1, fcmServerKey);
+//                       }
+//                     },
+//                   )
+//                 ]
+//             );
+//           }
+//         },
+//       )
+//     );
+//   }
 
-  Future<String> pushFirebaseNotification(int id, String firebaseServerKey) async {
+//   Future<String> pushFirebaseNotification(int id, String firebaseServerKey) async {
 
-    return await widget.firebaseDataSource.pushBasicNotification(
-      firebaseServerKey: firebaseServerKey,
-      firebaseAppToken: widget.firebaseAppToken,
-      notificationId: id,
-      title: 'Notification through firebase',
-      body: 'This notification was sent through firebase messaging cloud services.',
-      payload: {
-        'uuid': 'testPayloadKey'
-      }
-    );
-  }
-}
+//     return await widget.firebaseDataSource.pushBasicNotification(
+//       firebaseServerKey: firebaseServerKey,
+//       firebaseAppToken: widget.firebaseAppToken,
+//       notificationId: id,
+//       title: 'Notification through firebase',
+//       body: 'This notification was sent through firebase messaging cloud services.',
+//       payload: {
+//         'uuid': 'testPayloadKey'
+//       }
+//     );
+//   }
+// }

--- a/example/lib/pages/media_details_page.dart
+++ b/example/lib/pages/media_details_page.dart
@@ -5,12 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:palette_generator/palette_generator.dart';
-import 'package:progressive_image/progressive_image.dart';
 import 'package:awesome_notifications_example/models/media_model.dart';
 import 'package:awesome_notifications_example/utils/media_player_central.dart';
 
 class MediaDetailsPage extends StatefulWidget {
-
   MediaDetailsPage();
 
   @override
@@ -18,25 +16,23 @@ class MediaDetailsPage extends StatefulWidget {
 }
 
 class _MediaDetailsPageState extends State<MediaDetailsPage> {
-
-  ImageProvider diskImage;
+  ImageProvider? diskImage;
 
   bool isDraggin = false;
   bool closeCaptionActivated = false;
   bool hasCloseCaption = false;
 
+  bool? isLighten;
+  Color? mainColor;
+  Color? contrastColor;
 
-  bool isLighten;
-  Color mainColor;
-  Color contrastColor;
+  String? band;
+  String? music;
+  Duration? mediaLength;
+  Duration? durationPlayed;
 
-  String band;
-  String music;
-  Duration mediaLength;
-  Duration durationPlayed;
-
-  String _printDuration(Duration duration) {
-    if(duration == null) return '00:00';
+  String _printDuration(Duration? duration) {
+    if (duration == null) return '00:00';
     String twoDigits(int n) => n.toString().padLeft(2, "0");
     String twoDigitMinutes = twoDigits(duration.inMinutes.remainder(60));
     String twoDigitSeconds = twoDigits(duration.inSeconds.remainder(60));
@@ -52,9 +48,9 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
     });
 
     MediaPlayerCentral.progressStream.listen((moment) {
-      if(mounted){
+      if (mounted) {
         setState(() {
-          if(!isDraggin){
+          if (!isDraggin) {
             durationPlayed = moment;
           }
         });
@@ -65,13 +61,13 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
   }
 
   @override
-  dispose(){
+  dispose() {
     MediaPlayerCentral.mediaSink.close();
     MediaPlayerCentral.progressSink.close();
     super.dispose();
   }
 
-  bool computeLuminance(Color color){
+  bool computeLuminance(Color color) {
     return color.computeLuminance() > 0.5;
   }
 
@@ -83,10 +79,11 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
   Color getComplementaryColor(Color color) {
     int minColor = min(min(color.red, color.green), color.blue);
     int maxColor = max(max(color.red, color.green), color.blue);
-    return Color.fromARGB(255,
-        maxColor - minColor - color.red,
-        maxColor - minColor - color.green,
-        maxColor - minColor - color.blue,
+    return Color.fromARGB(
+      255,
+      maxColor - minColor - color.red,
+      maxColor - minColor - color.green,
+      maxColor - minColor - color.blue,
     );
     /*
     double y = (299 * color.red + 587 * color.green + 114 * color.blue) / 1000;
@@ -94,52 +91,45 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
     */
   }
 
-  Future<void> _updatePlayer({MediaModel media}) async {
-
-    if(media != null){
-
+  Future<void> _updatePlayer({MediaModel? media}) async {
+    if (media != null) {
       diskImage = media.diskImage;
       band = media.bandName;
       music = media.trackName;
       mediaLength = media.trackSize;
-      hasCloseCaption = media.closeCaption?.isNotEmpty ?? false;
-
+      hasCloseCaption = media.closeCaption.isNotEmpty;
     } else {
-
       diskImage = null;
       band = null;
       music = null;
       mediaLength = null;
       durationPlayed = Duration.zero;
-
     }
 
     _updatePaletteGenerator(media: media);
 
-    if(mounted) setState(() {});
-
+    if (mounted) setState(() {});
   }
 
-  Future<void> _updatePaletteGenerator({MediaModel media}) async {
-
-    PaletteGenerator paletteGenerator;
-    if(media != null){
+  Future<void> _updatePaletteGenerator({MediaModel? media}) async {
+    late PaletteGenerator paletteGenerator;
+    if (media != null) {
       paletteGenerator = await PaletteGenerator.fromImageProvider(
-        media.diskImage,
-        maximumColorCount: 5,
-        size: media.colorCaptureSize
-      );
+          media.diskImage,
+          maximumColorCount: 5,
+          size: media.colorCaptureSize);
     }
 
-    if(media != null && paletteGenerator.paletteColors.length  >= 1){
-      mainColor = paletteGenerator.dominantColor.color;
-      contrastColor = getContrastColor(mainColor).withOpacity(0.85);//paletteGenerator.paletteColors.last.color;//
+    if (media != null && paletteGenerator.paletteColors.length >= 1) {
+      mainColor = paletteGenerator.dominantColor!.color;
+      contrastColor = getContrastColor(mainColor!)
+          .withOpacity(0.85); //paletteGenerator.paletteColors.last.color;//
     } else {
       mainColor = null;
       contrastColor = null;
     }
 
-    if(this.mounted) setState(() {});
+    if (this.mounted) setState(() {});
   }
 
   @override
@@ -147,121 +137,122 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
     return _buildMediaPlayer(context);
   }
 
-  Widget _buildMediaPlayer(BuildContext context){
+  Widget _buildMediaPlayer(BuildContext context) {
     MediaQueryData mediaQueryData = MediaQuery.of(context);
     ThemeData themeData = Theme.of(context);
 
-    isLighten = isLighten ?? themeData.accentColorBrightness == Brightness.light;
+    isLighten =
+        isLighten ?? themeData.accentColorBrightness == Brightness.light;
     mainColor = mainColor ?? themeData.backgroundColor;
-    contrastColor = contrastColor ?? (isLighten ? Colors.black : Colors.white);
+    contrastColor = contrastColor ?? (isLighten! ? Colors.black : Colors.white);
 
     double maxSize = max(mediaQueryData.size.width, mediaQueryData.size.height);
 
     double imageHeight = (maxSize - mediaQueryData.padding.top) * 0.45;
-    double imageWidth  = mediaQueryData.size.width * 0.8;
+    double imageWidth = mediaQueryData.size.width * 0.8;
 
     return Theme(
         data: Theme.of(context).copyWith(
             primaryColor: mainColor,
             accentColor: contrastColor,
             scaffoldBackgroundColor: mainColor,
-            disabledColor: contrastColor.withOpacity(0.25),
-            textTheme: Theme.of(context).textTheme.copyWith(
-              headline2: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
-              headline3: TextStyle(fontSize: 18, fontWeight: FontWeight.w400),
-              headline6: TextStyle(fontSize: 18, fontWeight: FontWeight.w400),
-            ).apply(
-              bodyColor: contrastColor,
-              decorationColor: contrastColor,
-              displayColor: contrastColor,
-            ),
-            colorScheme: ColorScheme.light(
-              primary: contrastColor,
-            ),
+            disabledColor: contrastColor?.withOpacity(0.25),
+            textTheme: Theme.of(context)
+                .textTheme
+                .copyWith(
+                  headline2:
+                      TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+                  headline3:
+                      TextStyle(fontSize: 18, fontWeight: FontWeight.w400),
+                  headline6:
+                      TextStyle(fontSize: 18, fontWeight: FontWeight.w400),
+                )
+                .apply(
+                  bodyColor: contrastColor,
+                  decorationColor: contrastColor,
+                  displayColor: contrastColor,
+                ),
+            colorScheme: contrastColor != null
+                ? ColorScheme.light(primary: contrastColor!)
+                : null,
             buttonTheme: ButtonThemeData(
                 textTheme: ButtonTextTheme.accent,
-                disabledColor: contrastColor.withOpacity(0.25),
-                buttonColor: contrastColor
-            ),
-            iconTheme: IconThemeData(
-                color: contrastColor
-            ),
+                disabledColor: contrastColor?.withOpacity(0.25),
+                buttonColor: contrastColor),
+            iconTheme: IconThemeData(color: contrastColor),
             sliderTheme: SliderThemeData(
                 trackHeight: 4.0,
                 activeTrackColor: contrastColor,
-                inactiveTrackColor: contrastColor.withOpacity(0.25),
-                disabledInactiveTrackColor: contrastColor.withOpacity(0.25),
-                disabledThumbColor: contrastColor.withOpacity(0.25),
+                inactiveTrackColor: contrastColor?.withOpacity(0.25),
+                disabledInactiveTrackColor: contrastColor?.withOpacity(0.25),
+                disabledThumbColor: contrastColor?.withOpacity(0.25),
                 thumbColor: contrastColor,
-                thumbShape: RoundSliderThumbShape(enabledThumbRadius: 15)
-            ),
-            canvasColor: mainColor
-        ),
-        child: Builder(
-            builder: (BuildContext context){
-
-              return Scaffold(
-                  body: Stack(
-                    children: <Widget>[
-                      ListView(
-                        padding: EdgeInsets.zero,
-                        children: <Widget>[
-                          Container(
-                            constraints: BoxConstraints(
-                              minHeight: mediaQueryData.size.height,
-                              minWidth: mediaQueryData.size.width,
-                            ),
-                            child: Stack(
-                              children: <Widget>[
-                                _buildBackgroundMedia(mediaQueryData),
-                                _buildMediaPlayerContent(mediaQueryData, themeData, imageHeight, imageWidth, maxSize, context),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                      Positioned(
-                        top: mediaQueryData.padding.top + 10,
-                        left: 10,
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: mainColor,
-                            borderRadius: BorderRadius.only(
-                                topLeft: Radius.circular(10),
-                                topRight: Radius.circular(10),
-                                bottomLeft: Radius.circular(10),
-                                bottomRight: Radius.circular(10)
-                            ),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.black26,
-                                spreadRadius: 5,
-                                blurRadius: 7,
-                                offset: Offset(0, 3), // changes position of shadow
-                              ),
-                            ],
-                          ),
-                          width: 50,
-                          height: 40,
-                          child: IconButton(
-                            icon: Icon(Icons.arrow_back_ios),
-                            onPressed: () => Navigator.pop(context),
-                          ),
-                        ),
+                thumbShape: RoundSliderThumbShape(enabledThumbRadius: 15)),
+            canvasColor: mainColor),
+        child: Builder(builder: (BuildContext context) {
+          return Scaffold(
+              body: Stack(
+            children: <Widget>[
+              ListView(
+                padding: EdgeInsets.zero,
+                children: <Widget>[
+                  Container(
+                    constraints: BoxConstraints(
+                      minHeight: mediaQueryData.size.height,
+                      minWidth: mediaQueryData.size.width,
+                    ),
+                    child: Stack(
+                      children: <Widget>[
+                        _buildBackgroundMedia(mediaQueryData),
+                        _buildMediaPlayerContent(mediaQueryData, themeData,
+                            imageHeight, imageWidth, maxSize, context),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              Positioned(
+                top: mediaQueryData.padding.top + 10,
+                left: 10,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: mainColor,
+                    borderRadius: BorderRadius.only(
+                        topLeft: Radius.circular(10),
+                        topRight: Radius.circular(10),
+                        bottomLeft: Radius.circular(10),
+                        bottomRight: Radius.circular(10)),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black26,
+                        spreadRadius: 5,
+                        blurRadius: 7,
+                        offset: Offset(0, 3), // changes position of shadow
                       ),
                     ],
-                  )
-              );
-            }
-        )
-    );
+                  ),
+                  width: 50,
+                  height: 40,
+                  child: IconButton(
+                    icon: Icon(Icons.arrow_back_ios),
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                ),
+              ),
+            ],
+          ));
+        }));
   }
 
-  Padding _buildMediaPlayerContent(MediaQueryData mediaQueryData, ThemeData themeData, double imageHeight, double imageWidth, double maxSize, BuildContext context) {
+  Padding _buildMediaPlayerContent(
+      MediaQueryData mediaQueryData,
+      ThemeData themeData,
+      double imageHeight,
+      double imageWidth,
+      double maxSize,
+      BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(
-          top: mediaQueryData.padding.top + 20
-      ),
+      padding: EdgeInsets.only(top: mediaQueryData.padding.top + 20),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -269,10 +260,12 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
           Stack(
             children: <Widget>[
               Opacity(
-                opacity: closeCaptionActivated ? 0.08 : 1.0,
-                child: mediaArt(imageHeight, imageWidth, mediaQueryData, maxSize)
-              ),
-              closeCaptionActivated ? mediaCloseCaption(themeData, imageHeight, imageWidth, mediaQueryData, maxSize)
+                  opacity: closeCaptionActivated ? 0.08 : 1.0,
+                  child: mediaArt(
+                      imageHeight, imageWidth, mediaQueryData, maxSize)),
+              closeCaptionActivated
+                  ? mediaCloseCaption(themeData, imageHeight, imageWidth,
+                      mediaQueryData, maxSize)
                   : SizedBox.shrink()
             ],
           ),
@@ -284,16 +277,16 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
     );
   }
 
-  Widget mediaCloseCaption(ThemeData themeData, double imageHeight, double imageWidth, MediaQueryData mediaQueryData, double maxSize) {
-
-    TextStyle textStyle = themeData.textTheme.headline6.copyWith(color: contrastColor);
-    String subtitle = MediaPlayerCentral.getCloseCaption(durationPlayed);
+  Widget mediaCloseCaption(ThemeData themeData, double imageHeight,
+      double imageWidth, MediaQueryData mediaQueryData, double maxSize) {
+    TextStyle? textStyle =
+        themeData.textTheme.headline6?.copyWith(color: contrastColor);
+    String subtitle = MediaPlayerCentral.getCloseCaption(durationPlayed!);
 
     return Container(
-      width: mediaQueryData.size.width * 0.8,
-      height: imageHeight,
-      child: Center(child: Text(subtitle, style: textStyle))
-    );
+        width: mediaQueryData.size.width * 0.8,
+        height: imageHeight,
+        child: Center(child: Text(subtitle, style: textStyle)));
   }
 
   Widget mediaPlayerControllers(double maxSize) {
@@ -301,54 +294,66 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
       child: Container(
         height: maxSize * 0.15,
         width: maxSize * 0.8,
-        padding: EdgeInsets.symmetric(
-            horizontal: 0, vertical: 10),
+        padding: EdgeInsets.symmetric(horizontal: 0, vertical: 10),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            IconButton(icon: Icon(Icons.list),
+            IconButton(
+              icon: Icon(Icons.list),
               iconSize: maxSize * 0.05,
               onPressed: null,
             ),
-            IconButton(icon: Icon(Icons.skip_previous),
+            IconButton(
+              icon: Icon(Icons.skip_previous),
               iconSize: maxSize * 0.05,
-              onPressed: (durationPlayed == null || durationPlayed < MediaPlayerCentral.replayTolerance) && !MediaPlayerCentral.hasPreviousMedia ? null :
-                  (){
-                    MediaPlayerCentral.previousMedia();
-                    durationPlayed = MediaPlayerCentral.currentDuration;
-                  },
+              onPressed: (durationPlayed == null ||
+                          durationPlayed! <
+                              MediaPlayerCentral.replayTolerance) &&
+                      !MediaPlayerCentral.hasPreviousMedia
+                  ? null
+                  : () {
+                      MediaPlayerCentral.previousMedia();
+                      durationPlayed = MediaPlayerCentral.currentDuration;
+                    },
             ),
             Container(
               padding: EdgeInsets.all(5),
               margin: EdgeInsets.zero,
               decoration: BoxDecoration(
-                color: contrastColor.withOpacity(0.2),
+                color: contrastColor?.withOpacity(0.2),
                 shape: BoxShape.circle,
               ),
-              child: MediaPlayerCentral.isPlaying ?
-              IconButton(icon: Icon(Icons.pause_circle_filled),
-                padding: EdgeInsets.zero,
-                iconSize: maxSize * 0.08,
-                onPressed: !MediaPlayerCentral.hasAnyMedia ? null :
-                    () => MediaPlayerCentral.playPause(),
-              ) :
-              IconButton(icon: Icon(Icons.play_circle_filled),
-                padding: EdgeInsets.zero,
-                iconSize: maxSize * 0.08,
-                onPressed: !MediaPlayerCentral.hasAnyMedia ? null :
-                    () => MediaPlayerCentral.playPause(),
-              ),
+              child: MediaPlayerCentral.isPlaying
+                  ? IconButton(
+                      icon: Icon(Icons.pause_circle_filled),
+                      padding: EdgeInsets.zero,
+                      iconSize: maxSize * 0.08,
+                      onPressed: !MediaPlayerCentral.hasAnyMedia
+                          ? null
+                          : () => MediaPlayerCentral.playPause(),
+                    )
+                  : IconButton(
+                      icon: Icon(Icons.play_circle_filled),
+                      padding: EdgeInsets.zero,
+                      iconSize: maxSize * 0.08,
+                      onPressed: !MediaPlayerCentral.hasAnyMedia
+                          ? null
+                          : () => MediaPlayerCentral.playPause(),
+                    ),
             ),
-            IconButton(icon: Icon(Icons.skip_next),
+            IconButton(
+              icon: Icon(Icons.skip_next),
               iconSize: maxSize * 0.05,
-              onPressed: !MediaPlayerCentral.hasNextMedia ? null :
-                  (){
-                    MediaPlayerCentral.nextMedia();
-                    durationPlayed = MediaPlayerCentral.currentDuration;
-                  },
+              onPressed: !MediaPlayerCentral.hasNextMedia
+                  ? null
+                  : () {
+                      MediaPlayerCentral.nextMedia();
+                      durationPlayed = MediaPlayerCentral.currentDuration;
+                    },
             ),
-            IconButton(icon: Icon(CupertinoIcons.shuffle_medium),
+            IconButton(
+              icon: Icon(CupertinoIcons.shuffle_medium),
               iconSize: maxSize * 0.05,
               onPressed: null,
             )
@@ -359,145 +364,144 @@ class _MediaDetailsPageState extends State<MediaDetailsPage> {
   }
 
   Widget mediaTrackBar(double maxSize, MediaQueryData mediaQueryData) {
-
-    double maxValue = mediaLength?.inSeconds?.toDouble() ?? 0.0;
+    double maxValue = mediaLength?.inSeconds.toDouble() ?? 0.0;
 
     return Container(
-          margin: EdgeInsets.zero,
-          height: maxSize * 0.15,
-          width: mediaQueryData.size.width,
-          padding: EdgeInsets.only(
-              left: mediaQueryData.size.width * 0.05,
-              right: mediaQueryData.size.width * 0.05
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              Container(
-                  margin: EdgeInsets.zero,
-                  height: maxSize * 0.05,
-                  width: maxSize,
-                  child: Slider(
-                      min: 0.0,
-                      max: maxValue,
-                      value: min(maxValue, durationPlayed?.inSeconds?.toDouble() ?? 0.0),
-                      onChangeStart: (value) {
-                        isDraggin = true;
-                      },
-                      onChanged: (value) {
-                        setState(() {
-                          durationPlayed = Duration(seconds: value.toInt());
-                        });
-
-                      },
-                      onChangeEnd: (value) {
-                        isDraggin = false;
-                        setState(() {
-                          MediaPlayerCentral.goTo(durationPlayed);
-                        });
-                      }
-                  )
-              ),
-              SizedBox(height: 5),
-              Container(
-                padding: EdgeInsets.zero,
-                width: maxSize,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(_printDuration(durationPlayed)),
-                    hasCloseCaption ?
-                      IconButton(
-                        padding: EdgeInsets.zero,
-                        icon: Icon(Icons.closed_caption, size: 48, color: closeCaptionActivated ? contrastColor : contrastColor.withOpacity(0.5)),
-                        onPressed: () => closeCaptionActivated = !closeCaptionActivated,
-                      ):
-                      SizedBox(height: 47),
-                    Text(_printDuration(mediaLength), style: TextStyle(color: contrastColor)),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        );
-  }
-
-  Widget mediaInfo(double maxSize, MediaQueryData mediaQueryData, BuildContext context) {
-    return Container(
-          height: maxSize * 0.2 - mediaQueryData.padding.top,
-          width: mediaQueryData.size.width,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Text(
-                band ?? 'No track',
-                style: Theme.of(context).textTheme.headline2,
-                textAlign: TextAlign.center,
-              ),
-              SizedBox(height: maxSize * 0.01),
-              Text(
-                music ?? '',
-                style: Theme.of(context).textTheme.headline3,
-                textAlign: TextAlign.center,
-              )
-            ],
-          ),
-        );
-  }
-
-  Widget mediaArt(double imageHeight, double imageWidth, MediaQueryData mediaQueryData, double maxSize) {
-    return Center(
-          child: Container(
-              height: imageHeight,
-              width: imageWidth,
-              child: ShaderMask(
-                  shaderCallback: (rect) {
-                    return LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Colors.black,
-                          Colors.black,
-                          Colors.transparent
-                        ],
-                        stops: [0.0, 0.75, 0.98]
-                    ).createShader(Rect.fromLTRB(
-                        0, 0, rect.width, rect.height));
+      margin: EdgeInsets.zero,
+      height: maxSize * 0.15,
+      width: mediaQueryData.size.width,
+      padding: EdgeInsets.only(
+          left: mediaQueryData.size.width * 0.05,
+          right: mediaQueryData.size.width * 0.05),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Container(
+              margin: EdgeInsets.zero,
+              height: maxSize * 0.05,
+              width: maxSize,
+              child: Slider(
+                  min: 0.0,
+                  max: maxValue,
+                  value: min(
+                      maxValue, durationPlayed?.inSeconds.toDouble() ?? 0.0),
+                  onChangeStart: (value) {
+                    isDraggin = true;
                   },
-                  blendMode: BlendMode.dstIn,
-                  child: diskImage == null ?
-                  Container(
-                    width: mediaQueryData.size.width,
-                    height: (maxSize - mediaQueryData.padding.top) * 0.45,
-                    color: contrastColor.withOpacity(0.65)
-                  ) :
-                  ProgressiveImage(
-                    placeholder: AssetImage('assets/images/placeholder.gif'),
-                    thumbnail: AssetImage('assets/images/placeholder.gif'),
-                    image: diskImage,
-                    width: mediaQueryData.size.width,
-                    height: (maxSize - mediaQueryData.padding.top) * 0.45,
-                    fit: BoxFit.cover,
-                  )
-              )
+                  onChanged: (value) {
+                    setState(() {
+                      durationPlayed = Duration(seconds: value.toInt());
+                    });
+                  },
+                  onChangeEnd: (value) {
+                    isDraggin = false;
+                    setState(() {
+                      MediaPlayerCentral.goTo(durationPlayed!);
+                    });
+                  })),
+          SizedBox(height: 5),
+          Container(
+            padding: EdgeInsets.zero,
+            width: maxSize,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(_printDuration(durationPlayed)),
+                hasCloseCaption
+                    ? IconButton(
+                        padding: EdgeInsets.zero,
+                        icon: Icon(Icons.closed_caption,
+                            size: 48,
+                            color: closeCaptionActivated
+                                ? contrastColor
+                                : contrastColor?.withOpacity(0.5)),
+                        onPressed: () =>
+                            closeCaptionActivated = !closeCaptionActivated,
+                      )
+                    : SizedBox(height: 47),
+                Text(_printDuration(mediaLength),
+                    style: TextStyle(color: contrastColor)),
+              ],
+            ),
           ),
-        );
+        ],
+      ),
+    );
+  }
+
+  Widget mediaInfo(
+      double maxSize, MediaQueryData mediaQueryData, BuildContext context) {
+    return Container(
+      height: maxSize * 0.2 - mediaQueryData.padding.top,
+      width: mediaQueryData.size.width,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Text(
+            band ?? 'No track',
+            style: Theme.of(context).textTheme.headline2,
+            textAlign: TextAlign.center,
+          ),
+          SizedBox(height: maxSize * 0.01),
+          Text(
+            music ?? '',
+            style: Theme.of(context).textTheme.headline3,
+            textAlign: TextAlign.center,
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget mediaArt(double imageHeight, double imageWidth,
+      MediaQueryData mediaQueryData, double maxSize) {
+    return Center(
+      child: Container(
+        height: imageHeight,
+        width: imageWidth,
+        child: ShaderMask(
+            shaderCallback: (rect) {
+              return LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [Colors.black, Colors.black, Colors.transparent],
+                      stops: [0.0, 0.75, 0.98])
+                  .createShader(Rect.fromLTRB(0, 0, rect.width, rect.height));
+            },
+            blendMode: BlendMode.dstIn,
+            child:
+                // diskImage == null
+                //     ?
+                Container(
+                    width: mediaQueryData.size.width,
+                    height: (maxSize - mediaQueryData.padding.top) * 0.45,
+                    color: contrastColor?.withOpacity(0.65))
+            // : ProgressiveImage(
+            //     placeholder: AssetImage('assets/images/placeholder.gif'),
+            //     thumbnail: AssetImage('assets/images/placeholder.gif'),
+            //     image: diskImage,
+            //     width: mediaQueryData.size.width,
+            //     height: (maxSize - mediaQueryData.padding.top) * 0.45,
+            //     fit: BoxFit.cover,
+            //   ),
+            ),
+      ),
+    );
   }
 
   Widget _buildBackgroundMedia(MediaQueryData mediaQueryData) {
     return Container(
       height: mediaQueryData.size.height,
       width: mediaQueryData.size.width,
-      decoration: diskImage == null ? null : BoxDecoration(
-        image: DecorationImage(
-            image: diskImage,
-            fit: BoxFit.cover
-        ),
-      ),
+      decoration: diskImage == null
+          ? null
+          : BoxDecoration(
+              image: DecorationImage(image: diskImage!, fit: BoxFit.cover),
+            ),
       child: Container(
-        decoration: BoxDecoration(color: mainColor.withOpacity(0.93)),
+        decoration: BoxDecoration(color: mainColor?.withOpacity(0.93)),
       ),
     );
   }

--- a/example/lib/pages/notification_details_page.dart
+++ b/example/lib/pages/notification_details_page.dart
@@ -5,14 +5,11 @@ import 'package:flutter/material.dart' hide DateUtils;
 import 'package:flutter/material.dart' as Material show DateUtils;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_statusbarcolor/flutter_statusbarcolor.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
-import 'package:progressive_image/progressive_image.dart';
 import 'package:awesome_notifications/awesome_notifications.dart';
 
 class NotificationDetailsPage extends StatefulWidget {
-
   String get results => receivedNotification.toString();
   final ReceivedNotification receivedNotification;
 
@@ -21,109 +18,122 @@ class NotificationDetailsPage extends StatefulWidget {
   NotificationDetailsPage(this.receivedNotification);
 
   @override
-  _NotificationDetailsPageState createState() => _NotificationDetailsPageState();
+  _NotificationDetailsPageState createState() =>
+      _NotificationDetailsPageState();
 }
 
 class _NotificationDetailsPageState extends State<NotificationDetailsPage> {
-  String displayedDate = '';
+  String? displayedDate = '';
 
   @override
   void initState() {
     super.initState();
 
-    displayedDate =
-        DateUtils.parseDateToString(
-            DateUtils.utcToLocal(
-                DateUtils.parseStringToDate(widget.receivedNotification.displayedDate)
-            ),
-            format: 'dd/MM/yyyy HH:mm'
-        );
-  }
-
-  @override
-  void deactivate() {
-    FlutterStatusbarcolor.setStatusBarWhiteForeground(false);
-    super.deactivate();
+    displayedDate = DateUtils.parseDateToString(
+      DateUtils.parseStringToDate(widget.receivedNotification.displayedDate)
+          ?.toLocal(),
+      format: 'dd/MM/yyyy HH:mm',
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    FlutterStatusbarcolor.setStatusBarWhiteForeground(true);
-
     MediaQueryData mediaQueryData = MediaQuery.of(context);
     ThemeData themeData = Theme.of(context);
 
-    ImageProvider largeIcon = widget.receivedNotification.largeIconImage;
-    ImageProvider bigPicture = widget.receivedNotification.bigPictureImage;
+    ImageProvider? largeIcon = widget.receivedNotification.largeIconImage;
+    ImageProvider? bigPicture = widget.receivedNotification.bigPictureImage;
 
-    if(largeIcon == bigPicture) largeIcon = null;
+    if (largeIcon == bigPicture) largeIcon = null;
 
     double maxSize = max(mediaQueryData.size.width, mediaQueryData.size.height);
 
     return Scaffold(
         body: Stack(
+      children: <Widget>[
+        ListView(
+          padding: EdgeInsets.zero,
           children: <Widget>[
-            ListView(
-              padding: EdgeInsets.zero,
-              children: <Widget>[
-                Container(
-                  constraints: BoxConstraints(
-                    minHeight: mediaQueryData.size.height,
-                    minWidth: mediaQueryData.size.width,
-                  ),
-                  child: Column(
+            Container(
+              constraints: BoxConstraints(
+                minHeight: mediaQueryData.size.height,
+                minWidth: mediaQueryData.size.width,
+              ),
+              child: Column(
+                children: <Widget>[
+                  Stack(
                     children: <Widget>[
-                      Stack(
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
-                          Column(
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              bigPicture == null ?
-                              Container(
-                                height: mediaQueryData.padding.top + 80,
-                                width: mediaQueryData.size.width,
-                                decoration: BoxDecoration(
-                                    gradient: LinearGradient(
-                                        begin: Alignment.topCenter,
-                                        end: Alignment.bottomCenter,
-                                        colors: [Colors.black12, Colors.transparent],
-                                        stops: [0.0, 1.0]
-                                    )
-                                ),
-                              ) :
-                              Container(
-                                  height: maxSize * 0.4 + mediaQueryData.padding.top,
+                          bigPicture == null
+                              ? Container(
+                                  height: mediaQueryData.padding.top + 80,
+                                  width: mediaQueryData.size.width,
+                                  decoration: BoxDecoration(
+                                      gradient: LinearGradient(
+                                          begin: Alignment.topCenter,
+                                          end: Alignment.bottomCenter,
+                                          colors: [
+                                        Colors.black12,
+                                        Colors.transparent
+                                      ],
+                                          stops: [
+                                        0.0,
+                                        1.0
+                                      ])),
+                                )
+                              : Container(
+                                  height: maxSize * 0.4 +
+                                      mediaQueryData.padding.top,
                                   width: mediaQueryData.size.width,
                                   child: ShaderMask(
                                       shaderCallback: (rect) {
                                         return LinearGradient(
                                             begin: Alignment.topCenter,
                                             end: Alignment.bottomCenter,
-                                            colors: [Colors.black, Colors.black, Colors.transparent],
-                                            stops: [0.0, 0.75, 0.98]
-                                        ).createShader(Rect.fromLTRB(0, 0, rect.width, rect.height));
+                                            colors: [
+                                              Colors.black,
+                                              Colors.black,
+                                              Colors.transparent
+                                            ],
+                                            stops: [
+                                              0.0,
+                                              0.75,
+                                              0.98
+                                            ]).createShader(Rect.fromLTRB(
+                                            0, 0, rect.width, rect.height));
                                       },
                                       blendMode: BlendMode.dstIn,
                                       child: Padding(
-                                        padding: const EdgeInsets.only(bottom: 2.0), // 2 pixels to avoid render error on ShaderMask while the users are sliding the page
-                                        child: ProgressiveImage(
-                                          placeholder: AssetImage('assets/images/placeholder.gif'),
-                                          thumbnail: AssetImage('assets/images/placeholder.gif'),
-                                          image: widget.receivedNotification.bigPictureImage,
+                                        padding: const EdgeInsets.only(
+                                            bottom:
+                                                2.0), // 2 pixels to avoid render error on ShaderMask while the users are sliding the page
+                                        child: FadeInImage.assetNetwork(
+                                          placeholder:
+                                              'assets/images/placeholder.gif',
+                                          // thumbnail: AssetImage(
+                                          //     'assets/images/placeholder.gif'),
+                                          image: widget
+                                              .receivedNotification.bigPicture!,
                                           width: mediaQueryData.size.width,
-                                          height: maxSize * 0.4 + mediaQueryData.padding.top - 2,
+                                          height: maxSize * 0.4 +
+                                              mediaQueryData.padding.top -
+                                              2,
                                           fit: BoxFit.cover,
                                         ),
-                                      )
-                                  )
-                              ),
-                            ],
-                          ),
-                          largeIcon == null ? SizedBox() :
-                          Positioned(
-                              left: bigPicture == null ? mediaQueryData.size.width / 2 - 60 : 20,
-                              top: mediaQueryData.padding.top + (bigPicture == null ? 30 : maxSize * 0.25),
+                                      ))),
+                        ],
+                      ),
+                      largeIcon == null
+                          ? SizedBox()
+                          : Positioned(
+                              left: bigPicture == null
+                                  ? mediaQueryData.size.width / 2 - 60
+                                  : 20,
+                              top: mediaQueryData.padding.top +
+                                  (bigPicture == null ? 30 : maxSize * 0.25),
                               child: CircleAvatar(
                                 radius: maxSize * 0.08,
                                 backgroundColor: Color(0xffFDCF09),
@@ -131,76 +141,107 @@ class _NotificationDetailsPageState extends State<NotificationDetailsPage> {
                                     radius: maxSize * 0.075,
                                     backgroundColor: Colors.white,
                                     child: ClipOval(
-                                      child: ProgressiveImage(
-                                        placeholder: AssetImage('assets/images/placeholder.gif'),
-                                        thumbnail: AssetImage('assets/images/placeholder.gif'),
-                                        image: widget.receivedNotification.largeIconImage,
+                                      child: FadeInImage.assetNetwork(
+                                        placeholder:
+                                            'assets/images/placeholder.gif',
+                                        image: widget
+                                            .receivedNotification.largeIcon!,
                                         width: maxSize * 0.08 * 2,
                                         height: maxSize * 0.08 * 2,
                                         fit: BoxFit.cover,
                                       ),
                                     ) //widget.receivedNotification.largeIcon.image,
-                                ),
-                              )
-                          ),
-                          Container(
-                            width: mediaQueryData.size.width,
-                            padding: EdgeInsets.only(left: 20.0, right:20.0, bottom: 10, top: bigPicture == null ? (largeIcon == null ? 120 : 190) : maxSize * 0.48),
-                            child: RichText(
-                                text: TextSpan(
-                                    children: [
-                                      TextSpan(
-                                          text: widget.receivedNotification?.titleWithoutHtml ?? ((widget.receivedNotification?.body?.isEmpty ?? true) ? '' : widget.receivedNotification.bodyWithoutHtml),
-                                          style: TextStyle(fontSize: (widget.receivedNotification?.title?.isEmpty ?? true) ? 22 : 32, height: 1.2, color: Colors.black, fontWeight: FontWeight.bold)
-                                      ),
-                                      TextSpan(
-                                          text: '\n' + displayedDate,
-                                          style: themeData.textTheme.subtitle2.copyWith( color: Colors.black26 )
-                                      )
-                                    ]
-                                )
-                            ),
-                          )
-                        ],
-                      ),
-                      (widget.receivedNotification?.title?.isEmpty ?? true) ? SizedBox.shrink() :
-                      (widget.receivedNotification?.body?.isEmpty ?? true) ? SizedBox.shrink() :
+                                    ),
+                              )),
                       Container(
-                          width: mediaQueryData.size.width,
-                          padding: EdgeInsets.only(top: 10, left: 20, right: 20, bottom: 25),
-                          child: Text(widget.receivedNotification.bodyWithoutHtml, style: themeData.textTheme.bodyText2)
-                      ),
+                        width: mediaQueryData.size.width,
+                        padding: EdgeInsets.only(
+                            left: 20.0,
+                            right: 20.0,
+                            bottom: 10,
+                            top: bigPicture == null
+                                ? (largeIcon == null ? 120 : 190)
+                                : maxSize * 0.48),
+                        child: RichText(
+                            text: TextSpan(children: [
+                          TextSpan(
+                              text: widget
+                                      .receivedNotification?.titleWithoutHtml ??
+                                  ((widget.receivedNotification?.body
+                                              ?.isEmpty ??
+                                          true)
+                                      ? ''
+                                      : widget.receivedNotification
+                                          .bodyWithoutHtml),
+                              style:
+                                  TextStyle(
+                                      fontSize: (widget.receivedNotification
+                                                  ?.title?.isEmpty ??
+                                              true)
+                                          ? 22
+                                          : 32,
+                                      height: 1.2,
+                                      color: Colors.black,
+                                      fontWeight: FontWeight.bold)),
+                          TextSpan(
+                            text: '\n$displayedDate',
+                            style: themeData.textTheme.subtitle2
+                                ?.copyWith(color: Colors.black26),
+                          )
+                        ])),
+                      )
                     ],
                   ),
-                ),
-                Container(
-                  constraints: BoxConstraints(
-                    minWidth: mediaQueryData.size.width,
-                  ),
-                  child: Column(
-                    children: <Widget>[
-                      Container(
-                          width: mediaQueryData.size.width,
-                          color: themeData.dividerColor,
-                          padding: EdgeInsets.only(left: 10, right: 10, top:30, bottom: 30),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              Text('ReceivedNotification details:', style: themeData.textTheme.subtitle1.copyWith(color: themeData.hintColor)),
-                              SizedBox(height: 20 ),
-                              Text(widget.results, style: themeData.textTheme.bodyText2.copyWith(color: themeData.hintColor)),
-                            ],
-                          )
-                      ),
-                    ],
-                  ),
-                )
-              ],
+                  (widget.receivedNotification?.title?.isEmpty ?? true)
+                      ? SizedBox.shrink()
+                      : (widget.receivedNotification?.body?.isEmpty ?? true)
+                          ? SizedBox.shrink()
+                          : Container(
+                              width: mediaQueryData.size.width,
+                              padding: EdgeInsets.only(
+                                  top: 10, left: 20, right: 20, bottom: 25),
+                              child: Text(
+                                  widget.receivedNotification.bodyWithoutHtml,
+                                  style: themeData.textTheme.bodyText2)),
+                ],
+              ),
             ),
-            Theme.of(context).platform == TargetPlatform.android ?
-            SizedBox() :
-            Positioned(
+            Container(
+              constraints: BoxConstraints(
+                minWidth: mediaQueryData.size.width,
+              ),
+              child: Column(
+                children: <Widget>[
+                  Container(
+                      width: mediaQueryData.size.width,
+                      color: themeData.dividerColor,
+                      padding: EdgeInsets.only(
+                          left: 10, right: 10, top: 30, bottom: 30),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            'ReceivedNotification details:',
+                            style: themeData.textTheme.subtitle1
+                                ?.copyWith(color: themeData.hintColor),
+                          ),
+                          SizedBox(height: 20),
+                          Text(
+                            widget.results,
+                            style: themeData.textTheme.bodyText2
+                                ?.copyWith(color: themeData.hintColor),
+                          ),
+                        ],
+                      )),
+                ],
+              ),
+            )
+          ],
+        ),
+        Theme.of(context).platform == TargetPlatform.android
+            ? SizedBox()
+            : Positioned(
                 top: 0,
                 left: 0,
                 child: Container(
@@ -210,45 +251,50 @@ class _NotificationDetailsPageState extends State<NotificationDetailsPage> {
                       gradient: LinearGradient(
                           begin: Alignment.topCenter,
                           end: Alignment.bottomCenter,
-                          colors: [Colors.black54,Colors.black38, Colors.black12, Colors.transparent],
-                          stops: [0.2, 0.45, 0.75, 0.9]
-                      )
-                  ),
-                )
+                          colors: [
+                        Colors.black54,
+                        Colors.black38,
+                        Colors.black12,
+                        Colors.transparent
+                      ],
+                          stops: [
+                        0.2,
+                        0.45,
+                        0.75,
+                        0.9
+                      ])),
+                )),
+        Positioned(
+          top: mediaQueryData.padding.top + 10,
+          left: 10,
+          child: Container(
+            height: 40,
+            padding: EdgeInsets.zero,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(10),
+                  topRight: Radius.circular(10),
+                  bottomLeft: Radius.circular(10),
+                  bottomRight: Radius.circular(10)),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black26,
+                  spreadRadius: 5,
+                  blurRadius: 7,
+                  offset: Offset(0, 3), // changes position of shadow
+                ),
+              ],
             ),
-            Positioned(
-              top: mediaQueryData.padding.top + 10,
-              left: 10,
-              child: Container(
-                height: 40,
-                padding: EdgeInsets.zero,
-                alignment: Alignment.center,
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.only(
-                      topLeft: Radius.circular(10),
-                      topRight: Radius.circular(10),
-                      bottomLeft: Radius.circular(10),
-                      bottomRight: Radius.circular(10)
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black26,
-                      spreadRadius: 5,
-                      blurRadius: 7,
-                      offset: Offset(0, 3), // changes position of shadow
-                    ),
-                  ],
-                ),
-                child: IconButton(
-                  alignment: Alignment.center,
-                  icon: Icon(FontAwesomeIcons.chevronLeft),
-                  onPressed: () => Navigator.pop(context),
-                ),
-              ),
-            )
-          ],
+            child: IconButton(
+              alignment: Alignment.center,
+              icon: Icon(FontAwesomeIcons.chevronLeft),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ),
         )
-    );
+      ],
+    ));
   }
 }

--- a/example/lib/pages/notification_examples_page.dart
+++ b/example/lib/pages/notification_examples_page.dart
@@ -4,7 +4,6 @@ import 'package:awesome_notifications_example/common_widgets/led_light.dart';
 import 'package:flutter/material.dart' hide DateUtils;
 import 'package:flutter/material.dart' as Material show DateUtils;
 import 'package:flutter/services.dart';
-import 'package:flutter_statusbarcolor/flutter_statusbarcolor.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:awesome_notifications/awesome_notifications.dart';
 
@@ -20,49 +19,45 @@ import 'package:awesome_notifications_example/common_widgets/simple_button.dart'
 import 'package:awesome_notifications_example/common_widgets/text_divisor.dart';
 import 'package:awesome_notifications_example/common_widgets/text_note.dart';
 import 'package:numberpicker/numberpicker.dart';
-import 'package:giffy_dialog/giffy_dialog.dart';
 
 class NotificationExamplesPage extends StatefulWidget {
-
   @override
-  _NotificationExamplesPageState createState() => _NotificationExamplesPageState();
+  _NotificationExamplesPageState createState() =>
+      _NotificationExamplesPageState();
 }
 
 class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
-
   String _firebaseAppToken = '';
   //String _oneSignalToken = '';
 
-  MediaQueryData mediaQuery;
-
   bool delayLEDTests = false;
-  DateTime _pickedDate;
-  TimeOfDay _pickedTime;
+  DateTime? _pickedDate;
+  TimeOfDay? _pickedTime;
 
   bool notificationsAllowed = false;
 
   String packageName = 'me.carda.awesome_notifications_example';
 
   Future<bool> pickScheduleDate(BuildContext context) async {
-    TimeOfDay timeOfDay;
-    DateTime newDate = await showDatePicker(
+    TimeOfDay? timeOfDay;
+    DateTime? newDate = await showDatePicker(
         context: context,
         initialDate: _pickedDate ?? DateTime.now(),
         firstDate: DateTime.now(),
-        lastDate: DateTime.now().add(Duration(days: 365))
-    );
+        lastDate: DateTime.now().add(Duration(days: 365)));
 
-    if(newDate!= null){
-
+    if (newDate != null) {
       timeOfDay = await showTimePicker(
         context: context,
         initialTime: _pickedTime ?? TimeOfDay.now(),
       );
 
-      if(timeOfDay != null && (_pickedDate != newDate || _pickedTime != timeOfDay)){
+      if (timeOfDay != null &&
+          (_pickedDate != newDate || _pickedTime != timeOfDay)) {
         setState(() {
           _pickedTime = timeOfDay;
-          _pickedDate = DateTime(newDate.year, newDate.month, newDate.day, timeOfDay.hour, timeOfDay.minute);
+          _pickedDate = DateTime(newDate.year, newDate.month, newDate.day,
+              timeOfDay!.hour, timeOfDay.minute);
         });
         return true;
       }
@@ -72,41 +67,38 @@ class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
     return false;
   }
 
-  Future<int> pickBadgeCounter(BuildContext context) async {
-    int amount = 50;
-
-    AlertDialog alert = AlertDialog(
-      title: Text("Choose the new badge amount"),
-      content: NumberPicker.integer(
-          initialValue: amount,
-          minValue: 0,
-          maxValue: 999,
-          onChanged: (newValue) => amount = newValue
-      ),
-      actions: [
-        FlatButton(
-          child: Text("Cancel"),
-          onPressed: (){
-            amount = null;
-            Navigator.of(context).pop();
-          },
-        ),
-        FlatButton(
-          child: Text("OK"),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-      ],
-    );
-
+  Future<int?> pickBadgeCounter(BuildContext context) async {
     // show the dialog
-    await showDialog(
+    return showDialog<int?>(
       context: context,
-      builder: (BuildContext context) => alert
-    );
+      builder: (BuildContext context) {
+        int amount = 50;
 
-    return amount;
+        return AlertDialog(
+          title: Text("Choose the new badge amount"),
+          content: NumberPicker(
+            value: amount,
+            minValue: 0,
+            maxValue: 999,
+            onChanged: (newValue) => amount = newValue,
+          ),
+          actions: [
+            FlatButton(
+              child: Text("Cancel"),
+              onPressed: () {
+                Navigator.of(context).pop(null);
+              },
+            ),
+            FlatButton(
+              child: Text("OK"),
+              onPressed: () {
+                Navigator.of(context).pop(amount);
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -134,49 +126,36 @@ class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
     // getting a valid token
     // initializeFirebaseService();
 
-    AwesomeNotifications().createdStream.listen(
-            (receivedNotification) {
-          String createdSourceText = AssertUtils.toSimpleEnumString(
-              receivedNotification.createdSource);
-          Fluttertoast.showToast(
-              msg: '$createdSourceText notification created');
-        }
-    );
+    AwesomeNotifications().createdStream.listen((receivedNotification) {
+      String? createdSourceText =
+          AssertUtils.toSimpleEnumString(receivedNotification.createdSource);
+      Fluttertoast.showToast(msg: '$createdSourceText notification created');
+    });
 
-    AwesomeNotifications().displayedStream.listen(
-            (receivedNotification) {
-          String createdSourceText = AssertUtils.toSimpleEnumString(
-              receivedNotification.createdSource);
-          Fluttertoast.showToast(
-              msg: '$createdSourceText notification displayed');
-        }
-    );
+    AwesomeNotifications().displayedStream.listen((receivedNotification) {
+      String? createdSourceText =
+          AssertUtils.toSimpleEnumString(receivedNotification.createdSource);
+      Fluttertoast.showToast(msg: '$createdSourceText notification displayed');
+    });
 
-    AwesomeNotifications().dismissedStream.listen(
-            (receivedNotification) {
-          String dismissedSourceText = AssertUtils.toSimpleEnumString(
-              receivedNotification.dismissedLifeCycle);
-          Fluttertoast.showToast(
-              msg: 'Notification dismissed on $dismissedSourceText');
-        }
-    );
+    AwesomeNotifications().dismissedStream.listen((receivedNotification) {
+      String? dismissedSourceText = AssertUtils.toSimpleEnumString(
+          receivedNotification.dismissedLifeCycle);
+      Fluttertoast.showToast(
+          msg: 'Notification dismissed on $dismissedSourceText');
+    });
 
-    AwesomeNotifications().actionStream.listen(
-            (receivedNotification) {
-          if (!StringUtils.isNullOrEmpty(receivedNotification.buttonKeyInput)) {
-            processInputTextReceived(receivedNotification);
-          }
-          else if (
-          !StringUtils.isNullOrEmpty(receivedNotification.buttonKeyPressed) &&
-              receivedNotification.buttonKeyPressed.startsWith('MEDIA_')
-          ) {
-            processMediaControls(receivedNotification);
-          }
-          else {
-            processDefaultActionReceived(receivedNotification);
-          }
-        }
-    );
+    AwesomeNotifications().actionStream.listen((receivedNotification) {
+      if (!StringUtils.isNullOrEmpty(receivedNotification.buttonKeyInput)) {
+        processInputTextReceived(receivedNotification);
+      } else if (!StringUtils.isNullOrEmpty(
+              receivedNotification.buttonKeyPressed) &&
+          receivedNotification.buttonKeyPressed.startsWith('MEDIA_')) {
+        processMediaControls(receivedNotification);
+      } else {
+        processDefaultActionReceived(receivedNotification);
+      }
+    });
 
     AwesomeNotifications().isNotificationAllowed().then((isAllowed) {
       setState(() {
@@ -190,102 +169,142 @@ class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
   }
 
   void requestUserPermission(bool isAllowed) async {
-      showDialog(
-          context: context,
-          builder: (_) =>
-              NetworkGiffyDialog(
-                buttonOkText: Text('Allow', style: TextStyle(color: Colors.white)),
-                buttonCancelText: Text('Later', style: TextStyle(color: Colors.white)),
-                buttonCancelColor: Colors.grey,
-                buttonOkColor: Colors.deepPurple,
-                buttonRadius: 0.0,
-                image: Image.asset("assets/images/animated-bell.gif", fit: BoxFit.cover),
-                title: Text('Get Notified!',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                        fontSize: 22.0,
-                        fontWeight: FontWeight.w600)
-                ),
-                description: Text('Allow Awesome Notifications to send you beautiful notifications!',
-                  textAlign: TextAlign.center,
-                ),
-                entryAnimation: EntryAnimation.DEFAULT,
-                onCancelButtonPressed: () async {
-                  Navigator.of(context).pop();
-                  notificationsAllowed = await AwesomeNotifications().isNotificationAllowed();
-                  setState(() {
-                    notificationsAllowed = notificationsAllowed;
-                  });
-                },
-                onOkButtonPressed: () async {
-                  Navigator.of(context).pop();
-                  await AwesomeNotifications().requestPermissionToSendNotifications();
-                  notificationsAllowed = await AwesomeNotifications().isNotificationAllowed();
-                  setState(() {
-                    notificationsAllowed = notificationsAllowed;
-                  });
-                },
-              )
-      );
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text('Get Notified!',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 22.0, fontWeight: FontWeight.w600)),
+        content: Text(
+          'Allow Awesome Notifications to send you beautiful notifications!',
+          textAlign: TextAlign.center,
+        ),
+        actions: [
+          TextButton(
+            style: TextButton.styleFrom(backgroundColor: Colors.grey),
+            onPressed: () async {
+              Navigator.of(context).pop();
+              notificationsAllowed =
+                  await AwesomeNotifications().isNotificationAllowed();
+              setState(() {
+                notificationsAllowed = notificationsAllowed;
+              });
+            },
+            child: Text('Later', style: TextStyle(color: Colors.white)),
+          ),
+          TextButton(
+            style: TextButton.styleFrom(backgroundColor: Colors.deepPurple),
+            onPressed: () async {
+              Navigator.of(context).pop();
+              await AwesomeNotifications()
+                  .requestPermissionToSendNotifications();
+              notificationsAllowed =
+                  await AwesomeNotifications().isNotificationAllowed();
+              setState(() {
+                notificationsAllowed = notificationsAllowed;
+              });
+            },
+            child: Text('Allow', style: TextStyle(color: Colors.white)),
+          )
+        ],
+      ),
+    );
+    // showDialog(
+    //     context: context,
+    //     builder: (_) => NetworkGiffyDialog(
+    //           buttonOkText:
+    //               Text('Allow', style: TextStyle(color: Colors.white)),
+    //           buttonCancelText:
+    //               Text('Later', style: TextStyle(color: Colors.white)),
+    //           buttonCancelColor: Colors.grey,
+    //           buttonOkColor: Colors.deepPurple,
+    //           buttonRadius: 0.0,
+    //           image: Image.asset("assets/images/animated-bell.gif",
+    //               fit: BoxFit.cover),
+    //           title: Text('Get Notified!',
+    //               textAlign: TextAlign.center,
+    //               style:
+    //                   TextStyle(fontSize: 22.0, fontWeight: FontWeight.w600)),
+    //           description: Text(
+    //             'Allow Awesome Notifications to send you beautiful notifications!',
+    //             textAlign: TextAlign.center,
+    //           ),
+    //           entryAnimation: EntryAnimation.DEFAULT,
+    //           onCancelButtonPressed: () async {
+    //             Navigator.of(context).pop();
+    //             notificationsAllowed =
+    //                 await AwesomeNotifications().isNotificationAllowed();
+    //             setState(() {
+    //               notificationsAllowed = notificationsAllowed;
+    //             });
+    //           },
+    //           onOkButtonPressed: () async {
+    //             Navigator.of(context).pop();
+    //             await AwesomeNotifications()
+    //                 .requestPermissionToSendNotifications();
+    //             notificationsAllowed =
+    //                 await AwesomeNotifications().isNotificationAllowed();
+    //             setState(() {
+    //               notificationsAllowed = notificationsAllowed;
+    //             });
+    //           },
+    //         ));
   }
 
   void processDefaultActionReceived(ReceivedAction receivedNotification) {
+    Fluttertoast.showToast(msg: 'Action received');
 
-      Fluttertoast.showToast(msg: 'Action received');
+    String targetPage;
 
-      String targetPage;
+    // Avoid to reopen the media page if is already opened
+    if (receivedNotification.channelKey == 'media_player') {
+      targetPage = PAGE_MEDIA_DETAILS;
+      if (Navigator.of(context).isCurrent(PAGE_MEDIA_DETAILS)) return;
+    } else {
+      targetPage = PAGE_NOTIFICATION_DETAILS;
+    }
 
-      // Avoid to reopen the media page if is already opened
-      if(receivedNotification.channelKey == 'media_player'){
-
-        targetPage = PAGE_MEDIA_DETAILS;
-        if(Navigator.of(context).isCurrent(PAGE_MEDIA_DETAILS))
-          return;
-      }
-      else {
-        targetPage = PAGE_NOTIFICATION_DETAILS;
-      }
-
-      // Avoid to open the notification details page over another details page already opened
-      Navigator.pushNamedAndRemoveUntil(
-          context,
-          targetPage,
-              (route) => (route.settings.name != targetPage) || route.isFirst,
-          arguments: receivedNotification
-      );
-
+    // Avoid to open the notification details page over another details page already opened
+    Navigator.pushNamedAndRemoveUntil(context, targetPage,
+        (route) => (route.settings.name != targetPage) || route.isFirst,
+        arguments: receivedNotification);
   }
 
   void processInputTextReceived(ReceivedAction receivedNotification) {
-    Fluttertoast.showToast(msg: 'Msg: '+receivedNotification.buttonKeyInput, backgroundColor: App.mainColor, textColor: Colors.white);
+    Fluttertoast.showToast(
+        msg: 'Msg: ' + receivedNotification.buttonKeyInput,
+        backgroundColor: App.mainColor,
+        textColor: Colors.white);
   }
 
-  void processMediaControls(actionReceived){
+  void processMediaControls(actionReceived) {
+    switch (actionReceived.buttonKeyPressed) {
+      case 'MEDIA_CLOSE':
+        MediaPlayerCentral.stop();
+        break;
 
-      switch(actionReceived.buttonKeyPressed){
+      case 'MEDIA_PLAY':
+      case 'MEDIA_PAUSE':
+        MediaPlayerCentral.playPause();
+        break;
 
-        case 'MEDIA_CLOSE':
-          MediaPlayerCentral.stop();
-          break;
+      case 'MEDIA_PREV':
+        MediaPlayerCentral.previousMedia();
+        break;
 
-        case 'MEDIA_PLAY':
-        case 'MEDIA_PAUSE':
-          MediaPlayerCentral.playPause();
-          break;
+      case 'MEDIA_NEXT':
+        MediaPlayerCentral.nextMedia();
+        break;
 
-        case 'MEDIA_PREV':
-          MediaPlayerCentral.previousMedia();
-          break;
+      default:
+        break;
+    }
 
-        case 'MEDIA_NEXT':
-          MediaPlayerCentral.nextMedia();
-          break;
-
-        default:
-          break;
-      }
-
-      Fluttertoast.showToast(msg: 'Media: '+actionReceived.buttonKeyPressed.replaceFirst('MEDIA_', ''), backgroundColor: App.mainColor, textColor: Colors.white);
+    Fluttertoast.showToast(
+        msg: 'Media: ' +
+            actionReceived.buttonKeyPressed.replaceFirst('MEDIA_', ''),
+        backgroundColor: App.mainColor,
+        textColor: Colors.white);
   }
 
   @override
@@ -339,52 +358,42 @@ class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
 
   @override
   Widget build(BuildContext context) {
-
-    FlutterStatusbarcolor.setStatusBarWhiteForeground(false);
-
-    mediaQuery = MediaQuery.of(context);
+    final mediaQuery = MediaQuery.of(context);
     ThemeData themeData = Theme.of(context);
 
     return Scaffold(
+        appBar: AppBar(
+          centerTitle: false,
+          brightness: Brightness.light,
+          title: Image.asset(
+              'assets/images/awesome-notifications-logo-color.png',
+              width: mediaQuery.size.width *
+                  0.6), //Text('Local Notification Example App', style: TextStyle(fontSize: 20)),
+          elevation: 10,
+        ),
+        body: ListView(
+          padding: EdgeInsets.symmetric(horizontal: 15, vertical: 8),
+          children: <Widget>[
+            /* ******************************************************************** */
 
-      appBar: AppBar(
-        centerTitle: false,
-        brightness: Brightness.light, 
-        title: Image.asset(
-            'assets/images/awesome-notifications-logo-color.png',
-            width: mediaQuery.size.width * 0.6
-        ),//Text('Local Notification Example App', style: TextStyle(fontSize: 20)),
-        elevation: 10,
-      ),
-      body: ListView(
-        padding: EdgeInsets.symmetric( horizontal: 15, vertical:8 ),
-        children: <Widget>[
+            TextDivisor(title: 'Package name'),
+            RemarkableText(text: packageName, color: themeData.primaryColor),
+            SimpleButton('Copy package name', onPressed: () {
+              Clipboard.setData(ClipboardData(text: packageName));
+            }),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Package name' ),
-          RemarkableText( text: packageName, color: themeData.primaryColor),
-          SimpleButton(
-              'Copy package name',
-              onPressed: (){
-                Clipboard.setData(ClipboardData(text: packageName));
-              }
-          ),
-
-          /* ******************************************************************** */
-
-          TextDivisor( title: 'Push Service Status' ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: <Widget>[
-              ServiceControlPanel(
-                  'Firebase',
-                  !StringUtils.isNullOrEmpty(_firebaseAppToken),
-                  themeData,
-                  onPressed: () =>
-                      Navigator.pushNamed(context, PAGE_FIREBASE_TESTS, arguments: _firebaseAppToken )
-              ),
-              /*
+            TextDivisor(title: 'Push Service Status'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: <Widget>[
+                ServiceControlPanel('Firebase',
+                    !StringUtils.isNullOrEmpty(_firebaseAppToken), themeData,
+                    onPressed: () => Navigator.pushNamed(
+                        context, PAGE_FIREBASE_TESTS,
+                        arguments: _firebaseAppToken)),
+                /*
               /// TODO MISSING IMPLEMENTATION FOR ONE SIGNAL
               ServiceControlPanel(
                   'One Signal',
@@ -392,580 +401,450 @@ class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
                   themeData
               ),
               */
-            ],
-          ),
-          TextNote(
-              'Is not necessary to use Firebase (or other) services to use local notifications. But all they can be used simultaneously.'
-          ),
+              ],
+            ),
+            TextNote(
+                'Is not necessary to use Firebase (or other) services to use local notifications. But all they can be used simultaneously.'),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Permission to send Notifications' ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: <Widget>[
-              Column(
-                children: [
-                  Text(notificationsAllowed ? 'Allowed' : 'Not allowed', style: TextStyle(color: notificationsAllowed ? Colors.green : Colors.red)),
-                  LedLight(notificationsAllowed)
-                ],
-              )
-            ]
-          ),
-          TextNote(
-              'To send local and push notifications, it is necessary to obtain the user\'s consent. Keep in mind that he user consent can be revoked at any time.\n\n'
-                  '* Android: notifications are enabled by default and are considered not dangerous.\n'
-                  '* iOS: notifications are not enabled by default and you must explicitly request it to the user.'
-          ),
-          SimpleButton(
-              'Request permission',
-              onPressed: () => requestUserPermission(notificationsAllowed)
-          ),
+            TextDivisor(title: 'Permission to send Notifications'),
+            Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: <Widget>[
+                  Column(
+                    children: [
+                      Text(notificationsAllowed ? 'Allowed' : 'Not allowed',
+                          style: TextStyle(
+                              color: notificationsAllowed
+                                  ? Colors.green
+                                  : Colors.red)),
+                      LedLight(notificationsAllowed)
+                    ],
+                  )
+                ]),
+            TextNote(
+                'To send local and push notifications, it is necessary to obtain the user\'s consent. Keep in mind that he user consent can be revoked at any time.\n\n'
+                '* Android: notifications are enabled by default and are considered not dangerous.\n'
+                '* iOS: notifications are not enabled by default and you must explicitly request it to the user.'),
+            SimpleButton('Request permission',
+                onPressed: () => requestUserPermission(notificationsAllowed)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Get Next Schedule Date' ),
-          TextNote(
-              'A simple and fast notification to fresh start.\n\n'
-                  'Tap on notification when it appears on your system tray to go to Details page.'
-          ),
-          SimpleButton(
-              'Get Next Date',
-              onPressed: () async {
+            TextDivisor(title: 'Get Next Schedule Date'),
+            TextNote('A simple and fast notification to fresh start.\n\n'
+                'Tap on notification when it appears on your system tray to go to Details page.'),
+            SimpleButton('Get Next Date', onPressed: () async {
+              DateTime referenceDate =
+                  DateUtils.parseStringToDate('2021-01-12 20:00:00')!;
+              DateTime expectedDate =
+                  DateUtils.parseStringToDate('2021-01-12 21:00:00')!;
+              NotificationSchedule schedule =
+                  NotificationSchedule(initialDateTime: expectedDate);
 
-                DateTime referenceDate = DateUtils.parseStringToDate('2021-01-12 20:00:00');
-                DateTime expectedDate = DateUtils.parseStringToDate('2021-01-12 21:00:00');
-                NotificationSchedule schedule = NotificationSchedule(initialDateTime: expectedDate);
+              DateTime result = await AwesomeNotifications()
+                  .getNextDate(schedule, fixedDate: referenceDate);
+              debugPrint(DateUtils.parseDateToString(result));
+            }),
 
-                DateTime result = await AwesomeNotifications().getNextDate(schedule, fixedDate: referenceDate);
-                debugPrint(DateUtils.parseDateToString(result));
+            /* ******************************************************************** */
+
+            TextDivisor(title: 'Basic Notifications'),
+            TextNote('A simple and fast notification to fresh start.\n\n'
+                'Tap on notification when it appears on your system tray to go to Details page.'),
+            SimpleButton('Show the most basic notification',
+                onPressed: () => showBasicNotification(1)),
+            SimpleButton('Show notification with payload',
+                onPressed: () => showNotificationWithPayloadContent(1)),
+            SimpleButton('Show notification without body content',
+                onPressed: () => showNotificationWithoutBody(1)),
+            SimpleButton('Show notification without title content',
+                onPressed: () => showNotificationWithoutTitle(1)),
+            SimpleButton('Send background notification',
+                onPressed: () => sendBackgroundNotification(1)),
+            SimpleButton('Cancel the basic notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(1)),
+
+            /* ******************************************************************** */
+
+            TextDivisor(title: 'Big Picture Notifications'),
+            TextNote(
+                'To show any images on notification, at any place, you need to include the respective source prefix before the path.'
+                '\n\n'
+                'Images can be defined using 4 prefix types:'
+                '\n\n'
+                '* Asset: images access through Flutter asset method.\n\t Example:\n\t asset://path/to/image-asset.png'
+                '\n\n'
+                '* Network: images access through internet connection.\n\t Example:\n\t http(s)://url.com/to/image-asset.png'
+                '\n\n'
+                '* File: images access through files stored on device.\n\t Example:\n\t file://path/to/image-asset.png'
+                '\n\n'
+                '* Resource: images access through drawable native resources.\n\t Example:\n\t resource://url.com/to/image-asset.png'),
+            SimpleButton('Show large icon notification',
+                onPressed: () => showLargeIconNotification(2)),
+            SimpleButton('Show big picture notification\n(Network Source)',
+                onPressed: () => showBigPictureNetworkNotification(2)),
+            SimpleButton('Show big picture notification\n(Asset Source)',
+                onPressed: () => showBigPictureAssetNotification(2)),
+            SimpleButton('Show big picture notification\n(File Source)',
+                onPressed: () => showBigPictureFileNotification(2)),
+            SimpleButton('Show big picture notification\n(Resource Source)',
+                onPressed: () => showBigPictureResourceNotification(2)),
+            SimpleButton(
+                'Show big picture and\nlarge icon notification simultaneously',
+                onPressed: () => showBigPictureAndLargeIconNotification(2)),
+            SimpleButton(
+                'Show big picture notification,\n but hide large icon on expand',
+                onPressed: () =>
+                    showBigPictureNotificationHideExpandedLargeIcon(2)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(2)),
+
+            /* ******************************************************************** */
+
+            TextDivisor(
+                title:
+                    'Emojis ${Emojis.smile_alien}${Emojis.transport_air_rocket}'),
+            TextNote(
+                'To send local and push notifications with emojis, use the class Emoji concatenated with your text.\n\n'
+                'Attention: not all Emojis work with all platforms. Please, test the specific emoji before using it in production.'),
+            SimpleButton('Show notification with emojis',
+                onPressed: () => showEmojiNotification(1)),
+            SimpleButton(
+              'Go to complete Emojis list (web)',
+              onPressed: () => externalUrl(
+                  'https://unicode.org/emoji/charts/full-emoji-list.html'),
+            ),
+
+            /* ******************************************************************** */
+
+            TextDivisor(title: 'Locked Notifications (onGoing - Android)'),
+            TextNote(
+                'To send local or push locked notification, that users cannot dismiss it swiping it, set the "locked" property to true.\n\n' +
+                    "Attention: Notification's content locked property has priority over the Channel's one."),
+            SimpleButton('Send/Update the locked notification',
+                onPressed: () => showLockedNotification(2)),
+            SimpleButton('Send/Update the unlocked notification',
+                onPressed: () => showUnlockedNotification(2)),
+
+            /* ******************************************************************** */
+
+            TextDivisor(title: 'Notification Importance (Priority)'),
+            TextNote(
+                'To change the importance level of notifications, please set the importance in the respective channel.\n\n'
+                'The possible importance levels are the following:\n\n'
+                'Max: Makes a sound and appears as a heads-up notification.\n'
+                'Higher: shows everywhere, makes noise and peeks. May use full screen intents.\n'
+                'Default: shows everywhere, makes noise, but does not visually intrude.\n'
+                'Low: Shows in the shade, and potentially in the status bar (see shouldHideSilentStatusBarIcons()), but is not audibly intrusive\n.'
+                'Min: only shows in the shade, below the fold.\n'
+                'None: disable the channel\n\n'
+                "Attention: Notification's channel importance can only be defined on first time."),
+            SimpleButton('Display notification with NotificationImportance.Max',
+                onPressed: () =>
+                    showNotificationImportance(3, NotificationImportance.Max)),
+            SimpleButton(
+                'Display notification with NotificationImportance.High',
+                onPressed: () =>
+                    showNotificationImportance(3, NotificationImportance.High)),
+            SimpleButton(
+                'Display notification with NotificationImportance.Default',
+                onPressed: () => showNotificationImportance(
+                    3, NotificationImportance.Default)),
+            SimpleButton('Display notification with NotificationImportance.Low',
+                onPressed: () =>
+                    showNotificationImportance(3, NotificationImportance.Low)),
+            SimpleButton('Display notification with NotificationImportance.Min',
+                onPressed: () =>
+                    showNotificationImportance(3, NotificationImportance.Min)),
+            SimpleButton(
+                'Display notification with NotificationImportance.None',
+                onPressed: () =>
+                    showNotificationImportance(3, NotificationImportance.None)),
+
+            /* ******************************************************************** */
+
+            TextDivisor(title: 'Action Buttons'),
+            TextNote('Action buttons can be used in four types:'
+                '\n\n'
+                '* Default: after user taps, the notification bar is closed and an action event is fired.'
+                '\n\n'
+                '* InputField: after user taps, a input text field is displayed to capture input by the user.'
+                '\n\n'
+                '* DisabledAction: after user taps, the notification bar is closed, but the respective action event is not fired.'
+                '\n\n'
+                '* KeepOnTop: after user taps, the notification bar is not closed, but an action event is fired.'),
+            TextNote(
+                'Since Android Nougat, icons are only displayed on media layout. The icon media needs to be a native resource type.'),
+            SimpleButton(
+                'Show notification with\nsimple Action buttons (one disabled)',
+                onPressed: () => showNotificationWithActionButtons(3)),
+            SimpleButton('Show notification with\nIcons and Action buttons',
+                onPressed: () => showNotificationWithIconsAndActionButtons(3)),
+            SimpleButton('Show notification with\nReply and Action button',
+                onPressed: () => showNotificationWithActionButtonsAndReply(3)),
+            SimpleButton('Show Big picture notification\nwith Action Buttons',
+                onPressed: () => showBigPictureNotificationActionButtons(3)),
+            SimpleButton(
+                'Show Big picture notification\nwith Reply and Action button',
+                onPressed: () =>
+                    showBigPictureNotificationActionButtonsAndReply(3)),
+            SimpleButton(
+                'Show Big text notification\nwith Reply and Action button',
+                onPressed: () => showBigTextNotificationWithActionAndReply(3)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(3)),
+
+            /* ******************************************************************** */
+
+            TextDivisor(title: 'Badge Indicator'),
+            TextNote(
+                '"Badge" is an indicator of how many notifications (or anything else) that have not been viewed by the user (iOS and some versions of Android) '
+                'or even a reminder of new things arrived (Android native).\n\n'
+                'For platforms that show the global indicator over the app icon, is highly recommended to erase this annoying counter as soon '
+                'as possible and even let a shortcut menu with this option outside your app, similar to "mark as read" on e-mail. The amount counter '
+                'is automatically managed by this plugin for each individual installation, and incremented for every notification sent to channels '
+                'with "badge" set to TRUE.\n\n'
+                'OBS: Some Android distributions provide badge counter over the app icon, similar to iOS (LG, Samsung, HTC, Sony, etc) .\n\n'
+                'OBS2: Android has 2 badge counters. One global and other for each channel. You can only manipulate the global counter. The channels badge are automatically'
+                'managed by the system and is reset when all notifications are cleared or tapped.\n\n'
+                'OBS3: Badge channels for native Android only works on version 8.0 (API level 26) and beyond.'),
+            SimpleButton(
+                'Shows a notification with a badge indicator channel activate',
+                onPressed: () => showBadgeNotification(Random().nextInt(100))),
+            SimpleButton(
+                'Shows a notification with a badge indicator channel deactivate',
+                onPressed: () =>
+                    showWithoutBadgeNotification(Random().nextInt(100))),
+            SimpleButton('Read the badge indicator count', onPressed: () async {
+              int amount = await getBadgeIndicator();
+              Fluttertoast.showToast(msg: 'Badge count: $amount');
+            }),
+            SimpleButton('Set manually the badge indicator',
+                onPressed: () async {
+              int? amount = await pickBadgeCounter(context);
+              if (amount != null) {
+                setBadgeIndicator(amount);
               }
-          ),
+            }),
+            SimpleButton('Reset the badge indicator',
+                onPressed: () => resetBadgeIndicator()),
+            SimpleButton('Cancel all the badge test notifications',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelAllNotifications()),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Basic Notifications' ),
-          TextNote(
-              'A simple and fast notification to fresh start.\n\n'
-              'Tap on notification when it appears on your system tray to go to Details page.'
-          ),
-          SimpleButton(
-              'Show the most basic notification',
-              onPressed: () => showBasicNotification(1)
-          ),
-          SimpleButton(
-              'Show notification with payload',
-              onPressed: () => showNotificationWithPayloadContent(1)
-          ),
-          SimpleButton(
-              'Show notification without body content',
-              onPressed: () => showNotificationWithoutBody(1)
-          ),
-          SimpleButton(
-              'Show notification without title content',
-              onPressed: () => showNotificationWithoutTitle(1)
-          ),
-          SimpleButton(
-              'Send background notification',
-              onPressed: () => sendBackgroundNotification(1)
-          ),
-          SimpleButton(
-              'Cancel the basic notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(1)
-          ),
+            TextDivisor(title: 'Vibration Patterns'),
+            TextNote(
+                'The PushNotification plugin has 3 vibration patters as example, but you perfectly can create your own patter.'
+                '\n'
+                'The patter is made by a list of big integer, separated between ON and OFF duration in milliseconds.'),
+            TextNote(
+                'A vibration pattern pre-configured in a channel could be updated at any time using the method PushNotification.setChannel'),
+            SimpleButton('Show plain notification with low vibration pattern',
+                onPressed: () => showLowVibrationNotification(4)),
+            SimpleButton(
+                'Show plain notification with medium vibration pattern',
+                onPressed: () => showMediumVibrationNotification(4)),
+            SimpleButton('Show plain notification with high vibration pattern',
+                onPressed: () => showHighVibrationNotification(4)),
+            SimpleButton(
+                'Show plain notification with custom vibration pattern',
+                onPressed: () => showCustomVibrationNotification(4)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(4)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor(title: 'Big Picture Notifications'),
-          TextNote(
-              'To show any images on notification, at any place, you need to include the respective source prefix before the path.' '\n\n'
-              'Images can be defined using 4 prefix types:' '\n\n'
-                  '* Asset: images access through Flutter asset method.\n\t Example:\n\t asset://path/to/image-asset.png'
-                  '\n\n'
-                  '* Network: images access through internet connection.\n\t Example:\n\t http(s)://url.com/to/image-asset.png'
-                  '\n\n'
-                  '* File: images access through files stored on device.\n\t Example:\n\t file://path/to/image-asset.png'
-                  '\n\n'
-                  '* Resource: images access through drawable native resources.\n\t Example:\n\t resource://url.com/to/image-asset.png'
-          ),
-          SimpleButton(
-              'Show large icon notification',
-              onPressed: () => showLargeIconNotification(2)
-          ),
-          SimpleButton(
-              'Show big picture notification\n(Network Source)',
-              onPressed: () => showBigPictureNetworkNotification(2)
-          ),
-          SimpleButton(
-              'Show big picture notification\n(Asset Source)',
-              onPressed: () => showBigPictureAssetNotification(2)
-          ),
-          SimpleButton(
-              'Show big picture notification\n(File Source)',
-              onPressed: () => showBigPictureFileNotification(2)
-          ),
-          SimpleButton(
-              'Show big picture notification\n(Resource Source)',
-              onPressed: () => showBigPictureResourceNotification(2)
-          ),
-          SimpleButton(
-              'Show big picture and\nlarge icon notification simultaneously',
-              onPressed: () => showBigPictureAndLargeIconNotification(2)
-          ),
-          SimpleButton(
-              'Show big picture notification,\n but hide large icon on expand',
-              onPressed: () => showBigPictureNotificationHideExpandedLargeIcon(2)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(2)
-          ),
+            TextDivisor(title: 'Notification Channels'),
+            TextNote(
+                'The channel is a category identifier which notifications are pre-configured and organized before sent.'
+                '\n\n'
+                'On Android, since Oreo version, the notification channel is mandatory and can be managed by the user on your app config page.\n'
+                'Also channels can only update his title and description. All the other parameters could only be change if you erase the channel and recreates it with a different ID.'
+                'For other devices, such iOS, notification channels are emulated and used only as pre-configurations.'),
+            SimpleButton('Create a test channel called "Editable channel"',
+                onPressed: () => createTestChannel('Editable channel')),
+            SimpleButton(
+                'Update the title and description of "Editable channel"',
+                onPressed: () => updateTestChannel('Editable channel')),
+            SimpleButton('Remove "Editable channel"',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => removeTestChannel('Editable channel')),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Emojis ${Emojis.smile_alien}${Emojis.transport_air_rocket}' ),
-          TextNote(
-              'To send local and push notifications with emojis, use the class Emoji concatenated with your text.\n\n'
-                  'Attention: not all Emojis work with all platforms. Please, test the specific emoji before using it in production.'
-          ),
-          SimpleButton(
-              'Show notification with emojis',
-              onPressed: () => showEmojiNotification(1)
-          ),
-          SimpleButton(
-            'Go to complete Emojis list (web)',
-            onPressed: () => externalUrl('https://unicode.org/emoji/charts/full-emoji-list.html'),
-          ),
+            TextDivisor(title: 'LEDs and Colors'),
+            TextNote(
+                'The led colors and the default layout color are independent'),
+            TextNote('Some devices need to be locked to activate LED lights.'
+                '\n'
+                'If that is your case, please delay the notification to give to you enough time.'),
+            CheckButton('Delay notifications for 5 seconds', delayLEDTests,
+                onPressed: (value) {
+              setState(() {
+                delayLEDTests = value;
+              });
+            }),
+            SimpleButton('Notification with red text color\nand red LED',
+                onPressed: () => redNotification(5, delayLEDTests)),
+            SimpleButton('Notification with yellow text color\nand yellow LED',
+                onPressed: () => yellowNotification(5, delayLEDTests)),
+            SimpleButton('Notification with green text color\nand green LED',
+                onPressed: () => greenNotification(5, delayLEDTests)),
+            SimpleButton('Notification with blue text color\nand blue LED',
+                onPressed: () => blueNotification(5, delayLEDTests)),
+            SimpleButton('Notification with purple text color\nand purple LED',
+                onPressed: () => purpleNotification(5, delayLEDTests)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(5)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Locked Notifications (onGoing - Android)' ),
-          TextNote(
-              'To send local or push locked notification, that users cannot dismiss it swiping it, set the "locked" property to true.\n\n'+
-                  "Attention: Notification's content locked property has priority over the Channel's one."
-          ),
-          SimpleButton(
-              'Send/Update the locked notification',
-              onPressed: () => showLockedNotification(2)
-          ),
-          SimpleButton(
-              'Send/Update the unlocked notification',
-              onPressed: () => showUnlockedNotification(2)
-          ),
+            TextDivisor(title: 'Notification Sound'),
+            SimpleButton('Show notification with custom sound',
+                onPressed: () => showCustomSoundNotification(6)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(6)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Notification Importance (Priority)' ),
-          TextNote(
-              'To change the importance level of notifications, please set the importance in the respective channel.\n\n'
-                  'The possible importance levels are the following:\n\n'
-                  'Max: Makes a sound and appears as a heads-up notification.\n'
-                  'Higher: shows everywhere, makes noise and peeks. May use full screen intents.\n'
-                  'Default: shows everywhere, makes noise, but does not visually intrude.\n'
-                  'Low: Shows in the shade, and potentially in the status bar (see shouldHideSilentStatusBarIcons()), but is not audibly intrusive\n.'
-                  'Min: only shows in the shade, below the fold.\n'
-                  'None: disable the channel\n\n'
-                  "Attention: Notification's channel importance can only be defined on first time."
-          ),
-          SimpleButton(
-              'Display notification with NotificationImportance.Max',
-              onPressed: () => showNotificationImportance(3, NotificationImportance.Max)
-          ),
-          SimpleButton(
-              'Display notification with NotificationImportance.High',
-              onPressed: () => showNotificationImportance(3, NotificationImportance.High)
-          ),
-          SimpleButton(
-              'Display notification with NotificationImportance.Default',
-              onPressed: () => showNotificationImportance(3, NotificationImportance.Default)
-          ),
-          SimpleButton(
-              'Display notification with NotificationImportance.Low',
-              onPressed: () => showNotificationImportance(3, NotificationImportance.Low)
-          ),
-          SimpleButton(
-              'Display notification with NotificationImportance.Min',
-              onPressed: () => showNotificationImportance(3, NotificationImportance.Min)
-          ),
-          SimpleButton(
-              'Display notification with NotificationImportance.None',
-              onPressed: () => showNotificationImportance(3, NotificationImportance.None)
-          ),
+            TextDivisor(title: 'Silenced Notifications'),
+            SimpleButton('Show notification with no sound',
+                onPressed: () => showNotificationWithNoSound(7)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(7)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor( title: 'Action Buttons' ),
-          TextNote(
-              'Action buttons can be used in four types:' '\n\n'
-                  '* Default: after user taps, the notification bar is closed and an action event is fired.'
-                  '\n\n'
-                  '* InputField: after user taps, a input text field is displayed to capture input by the user.'
-                  '\n\n'
-                  '* DisabledAction: after user taps, the notification bar is closed, but the respective action event is not fired.'
-                  '\n\n'
-                  '* KeepOnTop: after user taps, the notification bar is not closed, but an action event is fired.'
-          ),
-          TextNote(
-              'Since Android Nougat, icons are only displayed on media layout. The icon media needs to be a native resource type.'
-          ),
-          SimpleButton(
-              'Show notification with\nsimple Action buttons (one disabled)',
-              onPressed: () => showNotificationWithActionButtons(3)
-          ),
-          SimpleButton(
-              'Show notification with\nIcons and Action buttons',
-              onPressed: () => showNotificationWithIconsAndActionButtons(3)
-          ),
-          SimpleButton(
-              'Show notification with\nReply and Action button',
-              onPressed: () => showNotificationWithActionButtonsAndReply(3)
-          ),
-          SimpleButton(
-              'Show Big picture notification\nwith Action Buttons',
-              onPressed: () => showBigPictureNotificationActionButtons(3)
-          ),
-          SimpleButton(
-              'Show Big picture notification\nwith Reply and Action button',
-              onPressed: () => showBigPictureNotificationActionButtonsAndReply(3)
-          ),
-          SimpleButton(
-              'Show Big text notification\nwith Reply and Action button',
-              onPressed: () => showBigTextNotificationWithActionAndReply(3)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(3)
-          ),
-
-          /* ******************************************************************** */
-
-          TextDivisor( title: 'Badge Indicator' ),
-          TextNote(
-              '"Badge" is an indicator of how many notifications (or anything else) that have not been viewed by the user (iOS and some versions of Android) '
-                  'or even a reminder of new things arrived (Android native).\n\n'
-                  'For platforms that show the global indicator over the app icon, is highly recommended to erase this annoying counter as soon '
-                  'as possible and even let a shortcut menu with this option outside your app, similar to "mark as read" on e-mail. The amount counter '
-                  'is automatically managed by this plugin for each individual installation, and incremented for every notification sent to channels '
-                  'with "badge" set to TRUE.\n\n'
-                  'OBS: Some Android distributions provide badge counter over the app icon, similar to iOS (LG, Samsung, HTC, Sony, etc) .\n\n'
-                  'OBS2: Android has 2 badge counters. One global and other for each channel. You can only manipulate the global counter. The channels badge are automatically'
-                  'managed by the system and is reset when all notifications are cleared or tapped.\n\n'
-                  'OBS3: Badge channels for native Android only works on version 8.0 (API level 26) and beyond.'
-          ),
-          SimpleButton(
-              'Shows a notification with a badge indicator channel activate',
-              onPressed: () => showBadgeNotification(Random().nextInt(100))
-          ),
-          SimpleButton(
-              'Shows a notification with a badge indicator channel deactivate',
-              onPressed: () => showWithoutBadgeNotification(Random().nextInt(100))
-          ),
-          SimpleButton(
-              'Read the badge indicator count',
-              onPressed: () async {
-                int amount = await getBadgeIndicator();
-                Fluttertoast.showToast(msg: 'Badge count: $amount');
+            TextDivisor(title: 'Scheduled Notifications'),
+            SimpleButton('Schedule notification', onPressed: () async {
+              if (await pickScheduleDate(context)) {
+                showNotificationAtScheduleCron(8, _pickedDate!);
               }
-          ),
-          SimpleButton(
-              'Set manually the badge indicator',
-              onPressed: () async {
-                int amount = await pickBadgeCounter(context);
-                if(amount != null){
-                  setBadgeIndicator(amount);
-                }
-              }
-          ),
-          SimpleButton(
-              'Reset the badge indicator',
-              onPressed: () => resetBadgeIndicator()
-          ),
-          SimpleButton(
-              'Cancel all the badge test notifications',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelAllNotifications()
-          ),
+            }),
+            SimpleButton(
+              'Show notification at every single minute',
+              onPressed: () => repeatMinuteNotification(8),
+            ),
+            SimpleButton(
+              'Show notification 3 times, spaced 10 seconds from each other',
+              onPressed: () => repeatPreciseThreeTimes(8),
+            ),
+            SimpleButton(
+              'Show notification at every single minute o\'clock',
+              onPressed: () => repeatMinuteNotificationOClock(8),
+            ),
+            SimpleButton(
+              'Show notification only on workweek days\nat 10:00 am (local)',
+              onPressed: () => showScheduleAtWorkweekDay10AmLocal(8),
+            ),
+            SimpleButton('List all active schedules',
+                onPressed: () => listScheduledNotifications(context)),
+            SimpleButton('Cancel single active schedule',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelSchedule(8)),
+            SimpleButton('Cancel all active schedules',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: cancelAllSchedules),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(8)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor(title: 'Vibration Patterns'),
-          TextNote(
-              'The PushNotification plugin has 3 vibration patters as example, but you perfectly can create your own patter.' '\n'
-              'The patter is made by a list of big integer, separated between ON and OFF duration in milliseconds.'
-          ),
-          TextNote(
-              'A vibration pattern pre-configured in a channel could be updated at any time using the method PushNotification.setChannel'
-          ),
-          SimpleButton(
-              'Show plain notification with low vibration pattern',
-              onPressed: () => showLowVibrationNotification(4)
-          ),
-          SimpleButton(
-              'Show plain notification with medium vibration pattern',
-              onPressed: () => showMediumVibrationNotification(4)
-          ),
-          SimpleButton(
-              'Show plain notification with high vibration pattern',
-              onPressed: () => showHighVibrationNotification(4)
-          ),
-          SimpleButton(
-              'Show plain notification with custom vibration pattern',
-              onPressed: () => showCustomVibrationNotification(4)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(4)
-          ),
+            TextDivisor(title: 'Media Player'),
+            TextNote(
+                'The media player its just emulated and was built to help me to check if the notification media control contemplates the dev demands, such as sync state, etc.'
+                '\n\n'
+                'The layout itself was built just for fun, you can use it as you wish for.'
+                '\n\n'
+                'ATENTION: There is no media reproducing in any place, its just a Timer to pretend a time passing.'),
+            SimpleButton('Show media player',
+                onPressed: () =>
+                    Navigator.pushNamed(context, PAGE_MEDIA_DETAILS)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(100)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor(title: 'Notification Channels'),
-          TextNote(
-              'The channel is a category identifier which notifications are pre-configured and organized before sent.' '\n\n'
-                  'On Android, since Oreo version, the notification channel is mandatory and can be managed by the user on your app config page.\n'
-                  'Also channels can only update his title and description. All the other parameters could only be change if you erase the channel and recreates it with a different ID.'
-                  'For other devices, such iOS, notification channels are emulated and used only as pre-configurations.'
-          ),
-          SimpleButton(
-              'Create a test channel called "Editable channel"',
-              onPressed: () => createTestChannel('Editable channel')
-          ),
-          SimpleButton(
-              'Update the title and description of "Editable channel"',
-              onPressed: () => updateTestChannel('Editable channel')
-          ),
-          SimpleButton(
-              'Remove "Editable channel"',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => removeTestChannel('Editable channel')
-          ),
+            TextDivisor(title: 'Progress Notifications'),
+            SimpleButton('Show indeterminate progress notification',
+                onPressed: () => showIndeterminateProgressNotification(9)),
+            SimpleButton('Show progress notification - updates every second',
+                onPressed: () => showProgressNotification(9)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(9)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor(title: 'LEDs and Colors'),
-          TextNote('The led colors and the default layout color are independent'),
-          TextNote(
-              'Some devices need to be locked to activate LED lights.' '\n'
-              'If that is your case, please delay the notification to give to you enough time.'),
-          CheckButton(
-              'Delay notifications for 5 seconds',
-              delayLEDTests,
-              onPressed: (value){
-                setState(() {
-                  delayLEDTests = value;
-                });
-              }
-          ),
-          SimpleButton(
-              'Notification with red text color\nand red LED',
-              onPressed: () => redNotification(5, delayLEDTests)
-          ),
-          SimpleButton(
-              'Notification with yellow text color\nand yellow LED',
-              onPressed: () => yellowNotification(5, delayLEDTests)
-          ),
-          SimpleButton(
-              'Notification with green text color\nand green LED',
-              onPressed: () => greenNotification(5, delayLEDTests)
-          ),
-          SimpleButton(
-              'Notification with blue text color\nand blue LED',
-              onPressed: () => blueNotification(5, delayLEDTests)
-          ),
-          SimpleButton(
-              'Notification with purple text color\nand purple LED',
-              onPressed: () => purpleNotification(5, delayLEDTests)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(5)
-          ),
+            TextDivisor(title: 'Inbox Notifications'),
+            SimpleButton(
+              'Show Inbox notification',
+              onPressed: () => showInboxNotification(10),
+            ),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(10)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor(title: 'Notification Sound'),
-          SimpleButton(
-              'Show notification with custom sound',
-              onPressed: () => showCustomSoundNotification(6)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(6)
-          ),
+            TextDivisor(title: 'Messaging Notifications'),
+            SimpleButton('Show Messaging notification\n(Work in progress)',
+                onPressed: null // showMessagingNotification(11)
+                ),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(11)),
 
-          /* ******************************************************************** */
+            /* ******************************************************************** */
 
-          TextDivisor(title: 'Silenced Notifications'),
-          SimpleButton(
-              'Show notification with no sound',
-              onPressed: () => showNotificationWithNoSound(7)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(7)
-          ),
+            TextDivisor(title: 'Grouped Notifications'),
+            SimpleButton('Show grouped notifications',
+                onPressed: () => showGroupedNotifications(12)),
+            SimpleButton('Cancel notification',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: () => cancelNotification(12)),
 
-          /* ******************************************************************** */
-
-          TextDivisor( title: 'Scheduled Notifications' ),
-          SimpleButton(
-              'Schedule notification',
-              onPressed: () async {
-                if(await pickScheduleDate(context)){
-                  showNotificationAtScheduleCron(8, _pickedDate);
-                }
-              }
-          ),
-          SimpleButton(
-            'Show notification at every single minute',
-            onPressed: () => repeatMinuteNotification(8),
-          ),
-          SimpleButton(
-            'Show notification 3 times, spaced 10 seconds from each other',
-            onPressed: () => repeatPreciseThreeTimes(8),
-          ),
-          SimpleButton(
-            'Show notification at every single minute o\'clock',
-            onPressed: () => repeatMinuteNotificationOClock(8),
-          ),
-          SimpleButton(
-            'Show notification only on workweek days\nat 10:00 am (local)',
-            onPressed: () => showScheduleAtWorkweekDay10AmLocal(8),
-          ),
-          SimpleButton(
-              'List all active schedules',
-              onPressed: () => listScheduledNotifications(context)
-          ),
-          SimpleButton(
-              'Cancel single active schedule',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelSchedule(8)
-          ),
-          SimpleButton(
-              'Cancel all active schedules',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: cancelAllSchedules
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(8)
-          ),
-
-          /* ******************************************************************** */
-
-          TextDivisor(title: 'Media Player'),
-          TextNote(
-              'The media player its just emulated and was built to help me to check if the notification media control contemplates the dev demands, such as sync state, etc.' '\n\n'
-                  'The layout itself was built just for fun, you can use it as you wish for.' '\n\n'
-                  'ATENTION: There is no media reproducing in any place, its just a Timer to pretend a time passing.'
-          ),
-          SimpleButton(
-              'Show media player',
-              onPressed: () => Navigator.pushNamed(context, PAGE_MEDIA_DETAILS)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(100)
-          ),
-
-          /* ******************************************************************** */
-
-          TextDivisor(title: 'Progress Notifications'),
-          SimpleButton(
-              'Show indeterminate progress notification',
-              onPressed: () => showIndeterminateProgressNotification(9)
-          ),
-          SimpleButton(
-              'Show progress notification - updates every second',
-              onPressed: () => showProgressNotification(9)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(9)
-          ),
-
-          /* ******************************************************************** */
-
-          TextDivisor(title: 'Inbox Notifications'),
-          SimpleButton(
-            'Show Inbox notification',
-            onPressed: () => showInboxNotification(10),
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(10)
-          ),
-
-          /* ******************************************************************** */
-
-          TextDivisor(title: 'Messaging Notifications'),
-          SimpleButton(
-              'Show Messaging notification\n(Work in progress)',
-              onPressed: null // showMessagingNotification(11)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(11)
-          ),
-
-          /* ******************************************************************** */
-
-          TextDivisor(title: 'Grouped Notifications'),
-          SimpleButton(
-              'Show grouped notifications',
-              onPressed: () => showGroupedNotifications(12)
-          ),
-          SimpleButton(
-              'Cancel notification',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: () => cancelNotification(12)
-          ),
-
-          /* ******************************************************************** */
-          TextDivisor(),
-          SimpleButton(
-              'Cancel all active schedules',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: cancelAllSchedules
-          ),
-          SimpleButton(
-              'Cancel all notifications',
-              backgroundColor: Colors.red,
-              labelColor: Colors.white,
-              onPressed: cancelAllNotifications
-          ),
-        ],
-      )
-    );
+            /* ******************************************************************** */
+            TextDivisor(),
+            SimpleButton('Cancel all active schedules',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: cancelAllSchedules),
+            SimpleButton('Cancel all notifications',
+                backgroundColor: Colors.red,
+                labelColor: Colors.white,
+                onPressed: cancelAllNotifications),
+          ],
+        ));
   }
 }

--- a/example/lib/pages/notification_examples_page.dart
+++ b/example/lib/pages/notification_examples_page.dart
@@ -132,7 +132,7 @@ class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
 
     // If you pretend to use the firebase service, you need to initialize it
     // getting a valid token
-    initializeFirebaseService();
+    // initializeFirebaseService();
 
     AwesomeNotifications().createdStream.listen(
             (receivedNotification) {
@@ -297,45 +297,45 @@ class _NotificationExamplesPageState extends State<NotificationExamplesPage> {
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
-  Future<void> initializeFirebaseService() async {
-    String firebaseAppToken;
-    bool isFirebaseAvailable;
+  // Future<void> initializeFirebaseService() async {
+  //   String firebaseAppToken;
+  //   bool isFirebaseAvailable;
 
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    try {
-      isFirebaseAvailable = await AwesomeNotifications().isFirebaseAvailable;
+  //   // Platform messages may fail, so we use a try/catch PlatformException.
+  //   try {
+  //     isFirebaseAvailable = await AwesomeNotifications().isFirebaseAvailable;
 
-      if(isFirebaseAvailable){
-        try {
-          firebaseAppToken = await AwesomeNotifications().firebaseAppToken;
-          debugPrint('Firebase token: $firebaseAppToken');
-        } on PlatformException {
-          firebaseAppToken = null;
-          debugPrint('Firebase failed to get token');
-        }
-      }
-      else {
-        firebaseAppToken = null;
-        debugPrint('Firebase is not available on this project');
-      }
+  //     if(isFirebaseAvailable){
+  //       try {
+  //         firebaseAppToken = await AwesomeNotifications().firebaseAppToken;
+  //         debugPrint('Firebase token: $firebaseAppToken');
+  //       } on PlatformException {
+  //         firebaseAppToken = null;
+  //         debugPrint('Firebase failed to get token');
+  //       }
+  //     }
+  //     else {
+  //       firebaseAppToken = null;
+  //       debugPrint('Firebase is not available on this project');
+  //     }
 
-    } on PlatformException {
-      isFirebaseAvailable = false;
-      firebaseAppToken = 'Firebase is not available on this project';
-    }
+  //   } on PlatformException {
+  //     isFirebaseAvailable = false;
+  //     firebaseAppToken = 'Firebase is not available on this project';
+  //   }
 
-    // If the widget was removed from the tree while the asynchronous platform
-    // message was in flight, we want to discard the reply rather than calling
-    // setState to update our non-existent appearance.
-    if (!mounted){
-      _firebaseAppToken = firebaseAppToken;
-      return;
-    }
+  //   // If the widget was removed from the tree while the asynchronous platform
+  //   // message was in flight, we want to discard the reply rather than calling
+  //   // setState to update our non-existent appearance.
+  //   if (!mounted){
+  //     _firebaseAppToken = firebaseAppToken;
+  //     return;
+  //   }
 
-    setState(() {
-      _firebaseAppToken = firebaseAppToken;
-    });
-  }
+  //   setState(() {
+  //     _firebaseAppToken = firebaseAppToken;
+  //   });
+  // }
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -1,3 +1,4 @@
+import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:flutter/material.dart';
 import 'package:awesome_notifications_example/pages/firebase_test_page.dart';
 
@@ -13,6 +14,8 @@ const String PAGE_FIREBASE_TESTS = '/firebase-tests';
 Map<String, WidgetBuilder> materialRoutes = {
   PAGE_HOME: (context) => NotificationExamplesPage(),
   PAGE_MEDIA_DETAILS: (context) => MediaDetailsPage(),
-  PAGE_NOTIFICATION_DETAILS: (context) => NotificationDetailsPage(ModalRoute.of(context).settings.arguments),
-  PAGE_FIREBASE_TESTS: (context) => FirebaseTestPage(ModalRoute.of(context).settings.arguments)
+  PAGE_NOTIFICATION_DETAILS: (context) => NotificationDetailsPage(
+        ModalRoute.of(context)!.settings.arguments as ReceivedNotification,
+      ),
+  // PAGE_FIREBASE_TESTS: (context) => FirebaseTestPage(ModalRoute.of(context).settings.arguments)
 };

--- a/example/lib/utils/common_functions.dart
+++ b/example/lib/utils/common_functions.dart
@@ -28,7 +28,7 @@ Future<String> downloadAndSaveImageOnDisk(String url, String fileName) async {
   var file = File(filePath);
 
   if(!await file.exists()){
-    var response = await http.get(url);
+    var response = await http.get(Uri.parse(url));
     await file.writeAsBytes(response.bodyBytes);
   }
 

--- a/example/lib/utils/media_player_central.dart
+++ b/example/lib/utils/media_player_central.dart
@@ -27,9 +27,9 @@ class MediaPlayerCentral {
   );
 
   static String getCloseCaption(Duration duration){
-    if( currentMedia?.closeCaption?.isEmpty ?? true ) return '';
+    if( currentMedia?.closeCaption.isEmpty ?? true ) return '';
 
-    for(CloseCaptionElement cc in currentMedia.closeCaption){
+    for(CloseCaptionElement cc in currentMedia!.closeCaption){
       if(cc.start <= duration && cc.end >= duration) return cc.subtitle;
     }
 
@@ -66,7 +66,7 @@ class MediaPlayerCentral {
 
   static MediaLifeCycle get mediaLifeCycle => _lifeCycle;
 
-  static MediaModel get currentMedia {
+  static MediaModel? get currentMedia {
     return _playlist.length == 0 ? null : _playlist[_index];
   }
 
@@ -81,7 +81,7 @@ class MediaPlayerCentral {
 
   static void _broadcastChanges(){
     _mediaBroadcaster.sink.add(
-        currentMedia
+        currentMedia!
     );
     _mediaProgress.sink.add(
         _timer.now
@@ -122,13 +122,13 @@ class MediaPlayerCentral {
       case MediaLifeCycle.Stopped:
       case MediaLifeCycle.Paused:
         _lifeCycle = MediaLifeCycle.Playing;
-        _timer.playPause(currentMedia.trackSize);
+        _timer.playPause(currentMedia!.trackSize);
         _broadcastChanges();
         break;
 
       case MediaLifeCycle.Playing:
         _lifeCycle = MediaLifeCycle.Paused;
-        _timer.playPause(currentMedia.trackSize);
+        _timer.playPause(currentMedia!.trackSize);
         _broadcastChanges();
         break;
     }
@@ -166,7 +166,7 @@ class MediaPlayerCentral {
 
       case MediaLifeCycle.Playing:
         _timer.stop();
-        _timer.playPause(currentMedia.trackSize);
+        _timer.playPause(currentMedia!.trackSize);
         _lifeCycle = MediaLifeCycle.Playing;
         break;
     }
@@ -184,7 +184,7 @@ class MediaPlayerCentral {
 
       case MediaLifeCycle.Playing:
         _timer.stop();
-        _timer.playPause(currentMedia.trackSize);
+        _timer.playPause(currentMedia!.trackSize);
         _lifeCycle = MediaLifeCycle.Playing;
         break;
 

--- a/example/lib/utils/notification_util.dart
+++ b/example/lib/utils/notification_util.dart
@@ -6,8 +6,10 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 // TO AVOID CONFLICT WITH MATERIAL DATE UTILS CLASS
-import 'package:awesome_notifications/awesome_notifications.dart' hide DateUtils;
-import 'package:awesome_notifications/awesome_notifications.dart' as Utils show DateUtils;
+import 'package:awesome_notifications/awesome_notifications.dart'
+    hide DateUtils;
+import 'package:awesome_notifications/awesome_notifications.dart' as Utils
+    show DateUtils;
 
 import 'package:awesome_notifications_example/models/media_model.dart';
 import 'package:awesome_notifications_example/utils/common_functions.dart';
@@ -38,29 +40,32 @@ Future<void> externalUrl(String url) async {
 ************************************************ */
 
 Future<void> showBasicNotification(int id) async {
-
   await AwesomeNotifications().createNotification(
       content: NotificationContent(
-          id: id,
-          channelKey: 'ringtone_channel',//'basic_channel',//'custom_sound',//
-          title: 'Simple Notification',
-          body: 'Simple body',
-      )/*,
+    id: id,
+    channelKey: 'ringtone_channel', //'basic_channel',//'custom_sound',//
+    title: 'Simple Notification',
+    body: 'Simple body',
+  ) /*,
       schedule: NotificationSchedule(
           initialDateTime: DateTime.now().add(Duration(seconds: 5)).toUtc()
       )*/
-  );
+      );
 }
 
 Future<void> showEmojiNotification(int id) async {
   await AwesomeNotifications().createNotification(
       content: NotificationContent(
-          id: id,
-          channelKey: 'basic_channel',
-          title: 'Emojis are awesome too! '+ Emojis.smile_face_with_tongue + Emojis.smile_rolling_on_the_floor_laughing + Emojis.smile_smiling_face_with_heart_eyes,
-          body: 'Simple body with a bunch of Emojis! ${Emojis.transport_police_car} ${Emojis.animals_dog} ${Emojis.flag_UnitedStates} ${Emojis.person_baby}',
-          bigPicture: 'https://tecnoblog.net/wp-content/uploads/2019/09/emoji.jpg',
-          notificationLayout: NotificationLayout.BigPicture,
+    id: id,
+    channelKey: 'basic_channel',
+    title: 'Emojis are awesome too! ' +
+        Emojis.smile_face_with_tongue +
+        Emojis.smile_rolling_on_the_floor_laughing +
+        Emojis.smile_smiling_face_with_heart_eyes,
+    body:
+        'Simple body with a bunch of Emojis! ${Emojis.transport_police_car} ${Emojis.animals_dog} ${Emojis.flag_UnitedStates} ${Emojis.person_baby}',
+    bigPicture: 'https://tecnoblog.net/wp-content/uploads/2019/09/emoji.jpg',
+    notificationLayout: NotificationLayout.BigPicture,
   ));
 }
 
@@ -110,12 +115,9 @@ Future<void> showBadgeNotification(int id) async {
           id: id,
           channelKey: 'badge_channel',
           title: 'Badge test notification',
-          body: 'This notification does activate badge indicator'
-      ),
+          body: 'This notification does activate badge indicator'),
       schedule: NotificationSchedule(
-          initialDateTime: DateTime.now().add(Duration(seconds: 5)).toUtc()
-      )
-  );
+          initialDateTime: DateTime.now().add(Duration(seconds: 5)).toUtc()));
 }
 
 Future<void> showWithoutBadgeNotification(int id) async {
@@ -124,12 +126,9 @@ Future<void> showWithoutBadgeNotification(int id) async {
           id: id,
           channelKey: 'basic_channel',
           title: 'Badge test notification',
-          body: 'This notification does not activate badge indicator'
-      ),
+          body: 'This notification does not activate badge indicator'),
       schedule: NotificationSchedule(
-          initialDateTime: DateTime.now().add(Duration(seconds: 5)).toUtc()
-      )
-  );
+          initialDateTime: DateTime.now().add(Duration(seconds: 5)).toUtc()));
 }
 
 // ON BADGE METHODS, NULL CHANNEL SETS THE GLOBAL COUNTER
@@ -222,8 +221,7 @@ Future<void> showLockedNotification(int id) async {
           channelKey: 'locked_notification',
           title: 'Locked notification',
           body: 'This notification is locked and cannot be dismissed',
-          payload: {'uuid': 'uuid-test'}
-      ));
+          payload: {'uuid': 'uuid-test'}));
 }
 
 Future<void> showUnlockedNotification(int id) async {
@@ -240,32 +238,28 @@ Future<void> showUnlockedNotification(int id) async {
           title: 'Unlocked notification',
           body: 'This notification is not locked and can be dismissed',
           payload: {'uuid': 'uuid-test'},
-          locked: false
-      ));
+          locked: false));
 }
 
 /* *********************************************
     NOTIFICATION CHANNELS MANIPULATION
 ************************************************ */
 
-Future<void> showNotificationImportance(int id, NotificationImportance importance) async {
-
+Future<void> showNotificationImportance(
+    int id, NotificationImportance importance) async {
   String importanceKey = importance.toString().toLowerCase().split('.').last;
-  String channelKey = 'importance_'+importanceKey+'_channel';
-  String title = 'Importance levels ('+importanceKey+')';
-  String body = 'Test of importance levels to '+importanceKey;
+  String channelKey = 'importance_' + importanceKey + '_channel';
+  String title = 'Importance levels (' + importanceKey + ')';
+  String body = 'Test of importance levels to ' + importanceKey;
 
-  await AwesomeNotifications().setChannel(
-      NotificationChannel(
-          channelKey: channelKey,
-          channelName: title,
-          channelDescription: body,
-          importance: importance,
-          defaultColor: Colors.red,
-          ledColor: Colors.red,
-          vibrationPattern: highVibrationPattern
-      )
-  );
+  await AwesomeNotifications().setChannel(NotificationChannel(
+      channelKey: channelKey,
+      channelName: title,
+      channelDescription: body,
+      importance: importance,
+      defaultColor: Colors.red,
+      ledColor: Colors.red,
+      vibrationPattern: highVibrationPattern));
 
   await AwesomeNotifications().createNotification(
       content: NotificationContent(
@@ -273,8 +267,7 @@ Future<void> showNotificationImportance(int id, NotificationImportance importanc
           channelKey: channelKey,
           title: title,
           body: body,
-          payload: {'uuid': 'uuid-test'}
-      ));
+          payload: {'uuid': 'uuid-test'}));
 }
 
 /* *********************************************
@@ -282,30 +275,23 @@ Future<void> showNotificationImportance(int id, NotificationImportance importanc
 ************************************************ */
 
 Future<void> createTestChannel(String channelName) async {
-
-  await AwesomeNotifications().setChannel(
-    NotificationChannel(
+  await AwesomeNotifications().setChannel(NotificationChannel(
       channelKey: channelName.toLowerCase().replaceAll(' ', '_'),
       channelName: channelName,
-      channelDescription: "Channel created to test the channels manipulation."
-    )
-  );
+      channelDescription:
+          "Channel created to test the channels manipulation."));
 }
 
 Future<void> updateTestChannel(String channelName) async {
-
-  await AwesomeNotifications().setChannel(
-      NotificationChannel(
-          channelKey: channelName.toLowerCase().replaceAll(' ', '_'),
-          channelName: channelName+" (updated)",
-          channelDescription: "This channel was successfuly updated."
-      )
-  );
+  await AwesomeNotifications().setChannel(NotificationChannel(
+      channelKey: channelName.toLowerCase().replaceAll(' ', '_'),
+      channelName: channelName + " (updated)",
+      channelDescription: "This channel was successfuly updated."));
 }
 
 Future<void> removeTestChannel(String channelName) async {
-
-  await AwesomeNotifications().removeChannel(channelName.toLowerCase().replaceAll(' ', '_'));
+  await AwesomeNotifications()
+      .removeChannel(channelName.toLowerCase().replaceAll(' ', '_'));
 }
 
 /* *********************************************
@@ -609,17 +595,15 @@ Future<void> showNotificationWithNoSound(int id) async {
 ************************************************ */
 
 Future<void> showBigPictureNetworkNotification(int id) async {
-
   await AwesomeNotifications().createNotification(
       content: NotificationContent(
           id: 11,
           channelKey: 'big_picture',
           title: 'Big picture (Network)',
           body: '$lorenIpsumText\n\n$lorenIpsumText\n\n$lorenIpsumText',
-          bigPicture: 'https://media.wired.com/photos/598e35994ab8482c0d6946e0/master/w_2560%2Cc_limit/phonepicutres-TA.jpg',
-          notificationLayout: NotificationLayout.BigPicture
-      )
-  );
+          bigPicture:
+              'https://media.wired.com/photos/598e35994ab8482c0d6946e0/master/w_2560%2Cc_limit/phonepicutres-TA.jpg',
+          notificationLayout: NotificationLayout.BigPicture));
 }
 
 Future<void> showBigPictureAssetNotification(int id) async {
@@ -641,8 +625,8 @@ Future<void> showBigPictureFileNotification(int id) async {
       'newTestImage.jpg');
 
   //String newFilePath = await saveImageOnDisk(AssetImage('assets/images/happy-dogs.jpg'),'newTestImage.jpg');
-  newFilePath = newFilePath?.replaceFirst('/', '');
-  String finalFilePath = 'file://' + (newFilePath ?? '');
+  newFilePath = newFilePath.replaceFirst('/', '');
+  String finalFilePath = 'file://' + (newFilePath);
 
   await AwesomeNotifications().createNotification(
       content: NotificationContent(
@@ -967,8 +951,7 @@ Future<void> showGroupedNotifications(id) async {
           id: 3,
           channelKey: 'grouped',
           title: 'Little Jhonny',
-          body: 'This push notifications plugin is amazing!'
-      ));
+          body: 'This push notifications plugin is amazing!'));
 
   sleep(Duration(seconds: 2));
 
@@ -977,8 +960,7 @@ Future<void> showGroupedNotifications(id) async {
           id: 4,
           channelKey: 'grouped',
           title: 'Little Jhonny',
-          body: 'Its perfect!'
-      ));
+          body: 'Its perfect!'));
 
   sleep(Duration(seconds: 2));
 
@@ -987,8 +969,7 @@ Future<void> showGroupedNotifications(id) async {
           id: 5,
           channelKey: 'grouped',
           title: 'Little Jhonny',
-          body: 'I gonna contribute with the project! For sure!'
-      ));
+          body: 'I gonna contribute with the project! For sure!'));
 }
 
 /* *********************************************
@@ -1000,7 +981,7 @@ Future<void> listScheduledNotifications(BuildContext context) async {
       await AwesomeNotifications().listScheduledNotifications();
   for (PushNotification schedule in activeSchedules) {
     debugPrint(
-        'pending notification: [id: ${schedule.content.id}, title: ${schedule.content.titleWithoutHtml}, initial: ${schedule.schedule.initialDateTime}, cron: ${schedule.schedule.crontabSchedule}]');
+        'pending notification: [id: ${schedule.content?.id}, title: ${schedule.content?.titleWithoutHtml}, initial: ${schedule.schedule?.initialDateTime}, cron: ${schedule.schedule?.crontabSchedule}]');
   }
   return showDialog<void>(
     context: context,
@@ -1066,24 +1047,21 @@ Future<void> repeatMinuteNotificationOClock(int id) async {
 
 Future<void> showNotificationAtScheduleCron(
     int id, DateTime scheduleTime) async {
-
   await AwesomeNotifications().createNotification(
-    content: NotificationContent(
-      id: id,
-      channelKey: 'scheduled',
-      title: 'Just in time!',
-      body: 'This notification was schedule to shows at ' +
-          Utils.DateUtils.parseDateToString(scheduleTime.toLocal()) +
-      '('+Utils.DateUtils.parseDateToString(scheduleTime.toUtc())+' utc)',
-      notificationLayout: NotificationLayout.BigPicture,
-      bigPicture: 'asset://assets/images/delivery.jpeg',
-      payload: {'uuid': 'uuid-test'},
-      autoCancel: false,
-    ),
-    schedule: NotificationSchedule(
-      crontabSchedule: CronHelper.instance.atDate(scheduleTime.toUtc(), initialSecond: 0)
-    )
-  );
+      content: NotificationContent(
+        id: id,
+        channelKey: 'scheduled',
+        title: 'Just in time!',
+        body:
+            'This notification was schedule to shows at ${Utils.DateUtils.parseDateToString(scheduleTime.toLocal())}(${Utils.DateUtils.parseDateToString(scheduleTime.toUtc())} utc)',
+        notificationLayout: NotificationLayout.BigPicture,
+        bigPicture: 'asset://assets/images/delivery.jpeg',
+        payload: {'uuid': 'uuid-test'},
+        autoCancel: false,
+      ),
+      schedule: NotificationSchedule(
+          crontabSchedule: CronHelper.instance
+              .atDate(scheduleTime.toUtc(), initialSecond: 0)));
 }
 
 Future<void> showScheduleAtWorkweekDay10AmLocal(int id) async {
@@ -1097,8 +1075,8 @@ Future<void> showScheduleAtWorkweekDay10AmLocal(int id) async {
       schedule: NotificationSchedule(
           crontabSchedule: CronHelper.instance.workweekDay(
               referenceUtcDate:
-                Utils.DateUtils.parseStringToDate('10:00', format: 'HH:mm')
-                      .toUtc())));
+                  Utils.DateUtils.parseStringToDate('10:00', format: 'HH:mm')
+                      ?.toUtc())));
 }
 
 Future<void> showNotificationWithNoBadge(int id) async {

--- a/example/lib/utils/playback_timer.dart
+++ b/example/lib/utils/playback_timer.dart
@@ -1,53 +1,54 @@
-
 import 'dart:async';
 
-
-
 class PlaybackTimer {
-
   Duration _clockTic = Duration(seconds: 1);
-  Duration _totalTime;
+  Duration? _totalTime;
 
   bool _isPlaying = false;
 
-  Timer _timer;
+  Timer? _timer;
   Duration _now = Duration.zero;
 
-  Function(Duration duration) _onDone;
-  Function(Duration duration) _onData;
+  Function(Duration duration)? _onDone;
+  Function(Duration duration)? _onData;
 
   PlaybackTimer({
-    Function(Duration duration) onDone,
-    Function(Duration duration) onData
-  }){
-    _onDone = onDone;
-    _onData = onData;
-  }
+    Function(Duration duration)? onDone,
+    Function(Duration duration)? onData,
+  })  : _onDone = onDone,
+        _onData = onData;
 
   Duration get now => _now;
-  set now(Duration duration){
+  set now(Duration duration) {
     _now = duration;
-    if(_onData != null) _onData(now);
+    if (_onData != null) _onData!(now);
   }
 
   bool get isPlaying => _isPlaying;
 
-  void playPause(Duration totalTime){
-    if(now == Duration.zero){ _startNewCycle(totalTime); return; }
-    if(_isPlaying) { _isPlaying = false; _timer.cancel(); return; }
+  void playPause(Duration totalTime) {
+    if (now == Duration.zero) {
+      _startNewCycle(totalTime);
+      return;
+    }
+    if (_isPlaying) {
+      _isPlaying = false;
+      _timer?.cancel();
+      return;
+    }
     _resume();
   }
 
-  void goTo(Duration moment){
-    if(moment == _totalTime) {
+  void goTo(Duration moment) {
+    if (moment == _totalTime) {
       stop();
-      if(_onDone != null) _onDone(now);
+      if (_onDone != null) _onDone!(now);
     } else {
       now = moment;
     }
   }
 
-  void stop(){
+  void stop() {
     _isPlaying = false;
 
     _timer?.cancel();
@@ -75,16 +76,14 @@ class PlaybackTimer {
     _timer = Timer(_clockTic, () {
       now += _clockTic;
 
-      if(now > _totalTime){
-        _timer.cancel();
+      if (now > _totalTime!) {
+        _timer!.cancel();
         now = Duration.zero;
 
-        if(isPlaying && _onDone != null) _onDone(now);
-      }
-      else {
+        if (isPlaying && _onDone != null) _onDone!(now);
+      } else {
         _resume();
       }
     });
-
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "3.1.2"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:
@@ -64,27 +64,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -106,46 +99,18 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.0"
-  flare_dart:
-    dependency: transitive
-    description:
-      name: flare_dart
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.3.4"
-  flare_flutter:
-    dependency: transitive
-    description:
-      name: flare_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.6"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_circular_slider:
-    dependency: "direct main"
-    description:
-      name: flutter_circular_slider
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.5.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
-  flutter_statusbarcolor:
-    dependency: "direct main"
-    description:
-      name: flutter_statusbarcolor
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.3"
+    version: "0.9.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -162,49 +127,35 @@ packages:
       name: fluttertoast
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "8.0.3"
   font_awesome_flutter:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.12.0"
-  giffy_dialog:
-    dependency: "direct main"
-    description:
-      name: giffy_dialog
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.0"
+    version: "9.0.0"
   http:
     dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   image:
     dependency: transitive
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.19"
-  infinite_listview:
-    dependency: transitive
-    description:
-      name: infinite_listview
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
+    version: "3.0.2"
   intl:
     dependency: "direct main"
     description:
@@ -239,14 +190,14 @@ packages:
       name: numberpicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.1"
   palette_generator:
     dependency: "direct main"
     description:
       name: palette_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.3.0"
   path:
     dependency: transitive
     description:
@@ -260,35 +211,35 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.28"
+    version: "2.0.1"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+2"
+    version: "2.0.0"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+8"
+    version: "2.0.0"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.5"
+    version: "2.0.0"
   pedantic:
     dependency: transitive
     description:
@@ -302,7 +253,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.1.0"
   platform:
     dependency: transitive
     description:
@@ -316,7 +267,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   process:
     dependency: transitive
     description:
@@ -324,55 +275,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
-  progressive_image:
-    dependency: "direct main"
-    description:
-      name: progressive_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.12+4"
+    version: "2.0.5"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2+4"
+    version: "2.0.0"
   shared_preferences_macos:
     dependency: transitive
     description:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+11"
+    version: "2.0.0"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+7"
+    version: "2.0.0"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2+3"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -433,42 +377,42 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.7.10"
+    version: "6.0.3"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+4"
+    version: "2.0.0"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+9"
+    version: "2.0.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.9"
+    version: "2.0.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5+3"
+    version: "2.0.0"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+3"
+    version: "2.0.0"
   vector_math:
     dependency: transitive
     description:
@@ -489,21 +433,21 @@ packages:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.2.0"
   xml:
     dependency: transitive
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.1"
+    version: "5.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5+6"
+    version: "0.0.5+8"
   boolean_selector:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.0"
   file:
     dependency: transitive
     description:
@@ -169,7 +169,7 @@ packages:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.8.1"
+    version: "8.12.0"
   giffy_dialog:
     dependency: "direct main"
     description:
@@ -197,14 +197,14 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.18"
+    version: "2.1.19"
   infinite_listview:
     dependency: transitive
     description:
       name: infinite_listview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1+1"
+    version: "1.1.0"
   intl:
     dependency: "direct main"
     description:
@@ -239,7 +239,7 @@ packages:
       name: numberpicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   palette_generator:
     dependency: "direct main"
     description:
@@ -260,7 +260,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.18"
+    version: "1.6.28"
   path_provider_linux:
     dependency: transitive
     description:
@@ -274,35 +274,35 @@ packages:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+4"
+    version: "0.0.4+8"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+1"
+    version: "0.0.5"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   platform:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   process:
     dependency: transitive
     description:
@@ -337,21 +337,21 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.12+2"
+    version: "0.5.12+4"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2+2"
+    version: "0.0.2+4"
   shared_preferences_macos:
     dependency: transitive
     description:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+10"
+    version: "0.0.1+11"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
@@ -372,7 +372,7 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+1"
+    version: "0.0.2+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -384,7 +384,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -433,21 +433,21 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.7.5"
+    version: "5.7.10"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+1"
+    version: "0.0.1+4"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+8"
+    version: "0.0.1+9"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -461,14 +461,14 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.5+3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+1"
+    version: "0.0.1+3"
   vector_math:
     dependency: transitive
     description:
@@ -482,7 +482,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.3"
+    version: "2.0.5"
   xdg_directories:
     dependency: transitive
     description:
@@ -505,5 +505,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ description: Demonstrates how to use the awesome_notifications plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -23,32 +23,32 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
-  font_awesome_flutter: ^8.8.1
-  fluttertoast: ^4.0.1
-  http: ^0.12.0
-  path_provider: ^1.4.0
-  shared_preferences: ^0.5.12+2
-  numberpicker: ^1.2.1
-  giffy_dialog: ^1.8.0
+  cupertino_icons: ^1.0.2
+  font_awesome_flutter: ^9.0.0
+  fluttertoast: ^8.0.3
+  http: ^0.13.1
+  path_provider: ^2.0.1
+  shared_preferences: ^2.0.5
+  numberpicker: ^2.0.1
+  # giffy_dialog: ^1.8.0
 
-  url_launcher: ^5.7.5
+  url_launcher: ^6.0.3
 
   intl: ^0.17.0
 
-  progressive_image: ^1.0.1
+  # progressive_image: ^1.0.1
 
-  palette_generator: ^0.2.3
+  palette_generator: ^0.3.0
 
-  flutter_circular_slider: ^2.5.0
+  # flutter_circular_slider: ^2.5.0
 
-  flutter_statusbarcolor: ^0.2.3
+  # flutter_statusbarcolor: ^0.2.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_launcher_icons: ^0.7.3
+  flutter_launcher_icons: ^0.9.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/src/awesome_notifications_core.dart
+++ b/lib/src/awesome_notifications_core.dart
@@ -18,7 +18,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 class AwesomeNotifications {
-  static String rootNativePath;
+  static String? rootNativePath;
 
   /// STREAM CREATION METHODS *********************************************
 
@@ -45,9 +45,9 @@ class AwesomeNotifications {
   /// STREAM METHODS *********************************************
 
   /// Stream to capture all FCM token updates. Could be changed at any time.
-  Stream<String> get fcmTokenStream {
-    return _tokenStreamController.stream;
-  }
+  // Stream<String> get fcmTokenStream {
+  //   return _tokenStreamController.stream;
+  // }
 
   /// Stream to capture all created notifications
   Stream<ReceivedNotification> get createdStream {
@@ -72,9 +72,9 @@ class AwesomeNotifications {
   /// SINK METHODS *********************************************
 
   /// Sink to dispose the stream, if you don't need it anymore.
-  Sink get fcmTokenSink {
-    return _tokenStreamController.sink;
-  }
+  // Sink get fcmTokenSink {
+  //   return _tokenStreamController.sink;
+  // }
 
   /// Sink to dispose the stream, if you don't need it anymore.
   Sink get createdSink {
@@ -126,7 +126,7 @@ class AwesomeNotifications {
   /// OBS: [defaultIcon] needs to be a Resource media type
   /// OBS 2: [channels] are updated if they already exists
   Future<bool> initialize(
-      String defaultIcon, List<NotificationChannel> channels) async {
+      String? defaultIcon, List<NotificationChannel> channels) async {
     WidgetsFlutterBinding.ensureInitialized();
 
     _channel.setMethodCallHandler(_handleMethod);
@@ -136,10 +136,10 @@ class AwesomeNotifications {
       serializedChannels.add(channel.toMap());
     }
 
-    String defaultIconPath;
+    String? defaultIconPath;
     if (!AssertUtils.isNullOrEmptyOrInvalid<String>(defaultIcon, String)) {
       // To set a icon on top of notification, is mandatory to user a native resource
-      assert(BitmapUtils().getMediaSource(defaultIcon) == MediaSource.Resource);
+      assert(BitmapUtils().getMediaSource(defaultIcon!) == MediaSource.Resource);
       defaultIconPath = defaultIcon;
     }
 
@@ -154,7 +154,7 @@ class AwesomeNotifications {
   /// NATIVE MEDIA METHODS *********************************************
 
   /// Decode a drawable resource bytes into a Uint8List to be used in Flutter widgets
-  Future<Uint8List> getDrawableData(String drawablePath) async {
+  Future<Uint8List?> getDrawableData(String drawablePath) async {
     var result2 = await _channel.invokeMethod(
         CHANNEL_METHOD_GET_DRAWABLE_DATA, drawablePath);
 
@@ -167,10 +167,10 @@ class AwesomeNotifications {
     Map<String, dynamic> arguments = Map<String, dynamic>.from(call.arguments);
 
     switch (call.method) {
-      case CHANNEL_METHOD_NEW_FCM_TOKEN:
-        final String token = call.arguments;
-        _tokenStreamController.add(token);
-        return;
+      // case CHANNEL_METHOD_NEW_FCM_TOKEN:
+      //   final String token = call.arguments;
+      //   _tokenStreamController.add(token);
+      //   return;
 
       case CHANNEL_METHOD_NOTIFICATION_CREATED:
         _createdSubject.sink.add(ReceivedNotification().fromMap(arguments));
@@ -183,12 +183,14 @@ class AwesomeNotifications {
         return;
 
       case CHANNEL_METHOD_NOTIFICATION_DISMISSED:
-        _dismissedSubject.sink.add(ReceivedAction().fromMap(arguments));
+        _dismissedSubject.sink
+            .add(ReceivedAction().fromMap(arguments) as ReceivedAction);
         debugPrint('Notification dismissed');
         return;
 
       case CHANNEL_METHOD_ACTION_RECEIVED:
-        _actionSubject.sink.add(ReceivedAction().fromMap(arguments));
+        _actionSubject.sink
+            .add(ReceivedAction().fromMap(arguments) as ReceivedAction);
         debugPrint('Action received');
         return;
 
@@ -207,18 +209,18 @@ class AwesomeNotifications {
   /// FIREBASE METHODS *********************************************
 
   /// Gets the firebase cloud messaging token
-  Future<String> get firebaseAppToken async {
-    final String token =
-        await _channel.invokeMethod(CHANNEL_METHOD_GET_FCM_TOKEN);
-    return token;
-  }
+  // Future<String> get firebaseAppToken async {
+  //   final String token =
+  //       await _channel.invokeMethod(CHANNEL_METHOD_GET_FCM_TOKEN);
+  //   return token;
+  // }
 
   /// Check if firebase is fully available on the project
-  Future<bool> get isFirebaseAvailable async {
-    final bool isAvailable =
-        await _channel.invokeMethod(CHANNEL_METHOD_IS_FCM_AVAILABLE);
-    return isAvailable;
-  }
+  // Future<bool> get isFirebaseAvailable async {
+  //   final bool isAvailable =
+  //       await _channel.invokeMethod(CHANNEL_METHOD_IS_FCM_AVAILABLE);
+  //   return isAvailable;
+  // }
 
   /// LOCAL NOTIFICATION METHODS *********************************************
 
@@ -226,11 +228,11 @@ class AwesomeNotifications {
   /// If notification has no [body] or [title], it will only be created, but never displayed. (background notification)
   /// [schedule] and [actionButtons] are optional
   Future<bool> createNotification({
-    @required NotificationContent content,
-    NotificationSchedule schedule,
-    List<NotificationActionButton> actionButtons,
+    required NotificationContent content,
+    NotificationSchedule? schedule,
+    List<NotificationActionButton>? actionButtons,
   }) async {
-    _validateId(content.id);
+    _validateId(content.id!);
 
     try {
       final bool wasCreated = await _channel.invokeMethod(
@@ -265,16 +267,18 @@ class AwesomeNotifications {
   /// List all active scheduled notifications.
   Future<List<PushNotification>> listScheduledNotifications() async {
     List<PushNotification> scheduledNotifications = [];
-    List<Object> returned =
+    List<Object>? returned =
         await _channel.invokeListMethod(CHANNEL_METHOD_LIST_ALL_SCHEDULES);
-    for (Object object in returned) {
-      if (object is Map) {
-        try {
-          PushNotification pushNotification =
-              PushNotification().fromMap(Map<String, dynamic>.from(object));
-          scheduledNotifications.add(pushNotification);
-        } catch (e) {
-          return [];
+    if (returned != null) {
+      for (Object object in returned) {
+        if (object is Map) {
+          try {
+            PushNotification pushNotification =
+                PushNotification().fromMap(Map<String, dynamic>.from(object))!;
+            scheduledNotifications.add(pushNotification);
+          } catch (e) {
+            return [];
+          }
         }
       }
     }
@@ -283,16 +287,15 @@ class AwesomeNotifications {
 
   /// Set a new notification channel or updates if already exists
   /// [forceUpdate]: completely updates the channel on Android Oreo and above, but cancels all current notifications.
-  Future<void> setChannel(NotificationChannel notificationChannel, {bool forceUpdate}) async {
+  Future<void> setChannel(
+    NotificationChannel notificationChannel, {
+    bool? forceUpdate,
+  }) async {
+    Map<String, dynamic> parameters = notificationChannel.toMap();
+    parameters.addAll({CHANNEL_FORCE_UPDATE: forceUpdate});
 
-    Map<String, dynamic> parameters =  notificationChannel.toMap();
-    parameters.addAll(
-        {
-          CHANNEL_FORCE_UPDATE: forceUpdate
-        }
-    );
-
-    await _channel.invokeMethod( CHANNEL_METHOD_SET_NOTIFICATION_CHANNEL, parameters );
+    await _channel.invokeMethod(
+        CHANNEL_METHOD_SET_NOTIFICATION_CHANNEL, parameters);
   }
 
   /// Remove a notification channel
@@ -326,16 +329,19 @@ class AwesomeNotifications {
     await _channel.invokeListMethod(CHANNEL_METHOD_RESET_BADGE);
   }
 
-  Future<DateTime> getNextDate(NotificationSchedule schedule, {DateTime fixedDate}) async {
+  Future<DateTime> getNextDate(
+    NotificationSchedule schedule, {
+    required DateTime fixedDate,
+  }) async {
     Map parameters = {
       NOTIFICATION_INITIAL_FIXED_DATE: DateUtils.parseDateToString(fixedDate),
       PUSH_NOTIFICATION_SCHEDULE: schedule.toMap()
     };
 
     final String nextDate =
-      await _channel.invokeMethod(CHANNEL_METHOD_GET_NEXT_DATE, parameters);
+        await _channel.invokeMethod(CHANNEL_METHOD_GET_NEXT_DATE, parameters);
 
-    return DateUtils.parseStringToDate(nextDate);
+    return DateUtils.parseStringToDate(nextDate)!;
   }
 
   /// Cancel a single notification

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -174,7 +174,7 @@ const NOTIFICATION_TICKER = 'ticker';
 const NOTIFICATION_ALLOW_WHILE_IDLE = 'allowWhileIdle';
 
 class Definitions {
-  static Map<String, Object> initialValues = {
+  static Map<String, Object?> initialValues = {
     NOTIFICATION_ID: 0,
     NOTIFICATION_GROUP_SORT: GroupSort.Desc,
     NOTIFICATION_GROUP_ALERT_BEHAVIOR: GroupAlertBehavior.All,

--- a/lib/src/extensions/extension_navigator_state.dart
+++ b/lib/src/extensions/extension_navigator_state.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/widgets.dart';
 
 extension NavigatorStateExtension on NavigatorState {
-  void pushNamedIfNotCurrent(String routeName, {Object arguments}) {
+  void pushNamedIfNotCurrent(String routeName, {Object? arguments}) {
     if (!isCurrent(routeName)) {
       pushNamed(routeName, arguments: arguments);
     }
   }
 
   Route getCurrentPage(String routeName) {
-    Route currentRoute;
+    late Route currentRoute;
     popUntil((route) {
       currentRoute = route;
       return true;

--- a/lib/src/helpers/bitmap_helper.dart
+++ b/lib/src/helpers/bitmap_helper.dart
@@ -52,8 +52,8 @@ class BitmapHelper {
     stream.addListener(listener);
     final imageInfo = await completer.future;
     final ui.Image image = imageInfo.image;
-    final ByteData byteData = await image.toByteData();
-    final Uint8List listInt = byteData.buffer.asUint8List();
+    final ByteData? byteData = await image.toByteData();
+    final Uint8List listInt = byteData!.buffer.asUint8List();
 
     return BitmapHelper.fromHeadless(image.width, image.height, listInt);
   }
@@ -106,7 +106,7 @@ class RGBA32BitmapHeader {
     );
   }
 
-  Uint8List headerIntList;
+  late Uint8List headerIntList;
 
   int get fileLength => contentSize + RGBA32HeaderSize;
 }

--- a/lib/src/helpers/cron_helper.dart
+++ b/lib/src/helpers/cron_helper.dart
@@ -11,14 +11,14 @@ import 'package:intl/intl.dart';
 /// OBS: Do not use <day-of-month> and <day-of-week> simultaneously. Chose one of
 /// then, marking the other one with ? tag to be ignored
 class CronHelper {
-  DateTime _fixedNow;
+  DateTime? _fixedNow;
 
   /// FACTORY METHODS *********************************************
 
   factory CronHelper() => instance;
 
   @visibleForTesting
-  CronHelper.private({DateTime fixedNow}) : _fixedNow = fixedNow;
+  CronHelper.private({DateTime? fixedNow}) : _fixedNow = fixedNow;
 
   static final CronHelper instance = CronHelper.private();
 
@@ -36,7 +36,7 @@ class CronHelper {
   }
 
   /// Generates a Cron expression to be played at only exact time
-  String atDate(DateTime referenceUtcDate, {int initialSecond}) {
+  String atDate(DateTime? referenceUtcDate, {int? initialSecond}) {
     if (initialSecond != null && initialSecond >= 0 && initialSecond <= 60) {
       if (initialSecond == 60) initialSecond = 0;
       return DateFormat('$initialSecond m H d M ? y')
@@ -47,38 +47,38 @@ class CronHelper {
   }
 
   /// Generates a Cron expression to be played only once at year from now
-  String yearly({DateTime referenceUtcDate}) {
+  String yearly({DateTime? referenceUtcDate}) {
     return DateFormat('s m H d M ? *')
         .format(referenceUtcDate ?? _getNow().toUtc());
   }
 
   /// Generates a Cron expression to be played only once at month from now
-  String monthly({DateTime referenceUtcDate}) {
+  String monthly({DateTime? referenceUtcDate}) {
     return DateFormat('s m H d * ? *')
         .format(referenceUtcDate ?? _getNow().toUtc());
   }
 
   /// Generates a Cron expression to be played only once at week from now
-  String weekly({DateTime referenceUtcDate}) {
+  String weekly({DateTime? referenceUtcDate}) {
     return DateFormat('s m H ? M E *')
         .format(referenceUtcDate ?? _getNow().toUtc())
         .toUpperCase();
   }
 
   /// Generates a Cron expression to be played only once at day from now
-  String daily({DateTime referenceUtcDate}) {
+  String daily({DateTime? referenceUtcDate}) {
     return DateFormat('s m H * * ? *')
         .format(referenceUtcDate ?? _getNow().toUtc());
   }
 
   /// Generates a Cron expression to be played only once at hour from now
-  String hourly({DateTime referenceUtcDate}) {
+  String hourly({DateTime? referenceUtcDate}) {
     return DateFormat('s m * * * ? *')
         .format(referenceUtcDate ?? _getNow().toUtc());
   }
 
   /// Generates a Cron expression to be played only once at every minute from now
-  String minutely({DateTime referenceUtcDate, int initialSecond}) {
+  String minutely({DateTime? referenceUtcDate, int? initialSecond}) {
     if (initialSecond != null && initialSecond >= 0 && initialSecond <= 60) {
       if (initialSecond == 60) initialSecond = 0;
       return DateFormat('$initialSecond * * * * ? *')
@@ -89,14 +89,14 @@ class CronHelper {
   }
 
   /// Generates a Cron expression to be played only on workweek days from now
-  String workweekDay({DateTime referenceUtcDate}) {
+  String workweekDay({DateTime? referenceUtcDate}) {
     return DateFormat('s m H ? * ')
             .format(referenceUtcDate ?? _getNow().toUtc()) +
         '$MON-$FRI *';
   }
 
   /// Generates a Cron expression to be played only on weekend days from now
-  String weekendDay({DateTime referenceUtcDate}) {
+  String weekendDay({DateTime? referenceUtcDate}) {
     return DateFormat('s m H ? * ')
             .format(referenceUtcDate ?? _getNow().toUtc()) +
         '$SAT,$SUN *';

--- a/lib/src/models/basic_notification_content.dart
+++ b/lib/src/models/basic_notification_content.dart
@@ -6,21 +6,21 @@ import 'package:awesome_notifications/src/utils/html_utils.dart';
 import 'package:flutter/material.dart';
 
 class BaseNotificationContent extends Model {
-  int id;
-  String channelKey;
-  String title;
-  String body;
-  String summary;
-  bool showWhen;
-  Map<String, dynamic> payload;
-  String icon;
-  String largeIcon;
-  String bigPicture;
-  String customSound;
-  bool autoCancel;
-  Color color;
-  Color backgroundColor;
-  NotificationPrivacy privacy;
+  int? id;
+  String? channelKey;
+  String? title;
+  String? body;
+  String? summary;
+  bool? showWhen;
+  Map<String, dynamic>? payload;
+  String? icon;
+  String? largeIcon;
+  String? bigPicture;
+  String? customSound;
+  bool? autoCancel;
+  Color? color;
+  Color? backgroundColor;
+  NotificationPrivacy? privacy;
 
   BaseNotificationContent({
     this.id,
@@ -89,16 +89,16 @@ class BaseNotificationContent extends Model {
   }
 
   ImageProvider get bigPictureImage {
-    return BitmapUtils().getFromMediaPath(bigPicture);
+    return BitmapUtils().getFromMediaPath(bigPicture!);
   }
 
   ImageProvider get largeIconImage {
-    return BitmapUtils().getFromMediaPath(largeIcon);
+    return BitmapUtils().getFromMediaPath(largeIcon!);
   }
 
-  String get titleWithoutHtml => HtmlUtils.removeAllHtmlTags(title);
+  String get titleWithoutHtml => HtmlUtils.removeAllHtmlTags(title)!;
 
-  String get bodyWithoutHtml => HtmlUtils.removeAllHtmlTags(body);
+  String get bodyWithoutHtml => HtmlUtils.removeAllHtmlTags(body)!;
 
   @override
   void validate() {

--- a/lib/src/models/model.dart
+++ b/lib/src/models/model.dart
@@ -5,7 +5,7 @@ abstract class Model {
   Map<String, dynamic> toMap();
 
   /// Exports all content into a serializable object
-  Model fromMap(Map<String, dynamic> mapData);
+  Model? fromMap(Map<String, dynamic> mapData);
 
   @override
   String toString() {

--- a/lib/src/models/notification_button.dart
+++ b/lib/src/models/notification_button.dart
@@ -16,11 +16,11 @@ import 'package:awesome_notifications/src/utils/string_utils.dart';
 /// [ActionButtonType.DisabledAction]: after user taps, the notification bar is closed, but the respective action event is not fired.
 /// [ActionButtonType.KeepOnTop]: after user taps, the notification bar is not closed, but an action event is fired.
 class NotificationActionButton extends Model {
-  String key;
-  String label;
-  String icon;
-  bool enabled;
-  bool autoCancel;
+  String? key;
+  String? label;
+  String? icon;
+  bool? enabled;
+  bool? autoCancel;
   ActionButtonType buttonType;
 
   NotificationActionButton(
@@ -43,7 +43,7 @@ class NotificationActionButton extends Model {
 
     // For action buttons, it's only allowed resource media types
     assert(StringUtils.isNullOrEmpty(icon) ||
-        BitmapUtils().getMediaSource(icon) == MediaSource.Resource);
+        BitmapUtils().getMediaSource(icon!) == MediaSource.Resource);
 
     return this;
   }

--- a/lib/src/models/notification_channel.dart
+++ b/lib/src/models/notification_channel.dart
@@ -15,62 +15,61 @@ import 'package:flutter/material.dart';
 /// A representation of default settings that applies to all notifications with same channel key
 /// [soundSource] needs to be a native resource media type
 class NotificationChannel extends Model {
-  String channelKey;
-  String channelName;
-  String channelDescription;
-  bool channelShowBadge;
+  String? channelKey;
+  String? channelName;
+  String? channelDescription;
+  bool? channelShowBadge;
 
-  NotificationImportance importance;
+  NotificationImportance? importance;
 
-  bool playSound;
-  String soundSource;
-  DefaultRingtoneType defaultRingtoneType;
+  bool? playSound;
+  String? soundSource;
+  DefaultRingtoneType? defaultRingtoneType;
 
-  bool enableVibration;
-  Int64List vibrationPattern;
+  bool? enableVibration;
+  Int64List? vibrationPattern;
 
-  bool enableLights;
-  Color ledColor;
-  int ledOnMs;
-  int ledOffMs;
+  bool? enableLights;
+  Color? ledColor;
+  int? ledOnMs;
+  int? ledOffMs;
 
-  String groupKey;
-  GroupSort groupSort;
-  GroupAlertBehavior groupAlertBehavior;
+  String? groupKey;
+  GroupSort? groupSort;
+  GroupAlertBehavior? groupAlertBehavior;
 
-  NotificationPrivacy defaultPrivacy;
+  NotificationPrivacy? defaultPrivacy;
 
-  String icon;
-  Color defaultColor;
+  String? icon;
+  Color? defaultColor;
 
-  bool locked;
-  bool onlyAlertOnce;
+  bool? locked;
+  bool? onlyAlertOnce;
 
-  NotificationChannel(
-      {Key key,
-      this.channelKey,
-      this.channelName,
-      this.channelDescription,
-      this.channelShowBadge,
-      this.importance,
-      this.playSound,
-      this.soundSource,
-      this.defaultRingtoneType,
-      this.enableVibration,
-      this.vibrationPattern,
-      this.enableLights,
-      this.ledColor,
-      this.ledOnMs,
-      this.ledOffMs,
-      this.groupKey,
-      this.groupSort,
-      this.groupAlertBehavior,
-      this.icon,
-      this.defaultColor,
-      this.locked,
-      this.onlyAlertOnce,
-      this.defaultPrivacy})
-      : super() {
+  NotificationChannel({
+    this.channelKey,
+    this.channelName,
+    this.channelDescription,
+    this.channelShowBadge,
+    this.importance,
+    this.playSound,
+    this.soundSource,
+    this.defaultRingtoneType,
+    this.enableVibration,
+    this.vibrationPattern,
+    this.enableLights,
+    this.ledColor,
+    this.ledOnMs,
+    this.ledOffMs,
+    this.groupKey,
+    this.groupSort,
+    this.groupAlertBehavior,
+    this.icon,
+    this.defaultColor,
+    this.locked,
+    this.onlyAlertOnce,
+    this.defaultPrivacy,
+  }) : super() {
     this.channelKey =
         AssertUtils.getValueOrDefault('channelKey', this.channelKey, String);
     this.channelName =
@@ -98,8 +97,8 @@ class NotificationChannel extends Model {
         AssertUtils.getValueOrDefault('ledOffMs', this.ledOffMs, int);
     this.groupKey =
         AssertUtils.getValueOrDefault('groupKey', this.groupKey, String);
-    this.groupSort = AssertUtils.getValueOrDefault(
-        'groupSort', this.groupSort, GroupSort);
+    this.groupSort =
+        AssertUtils.getValueOrDefault('groupSort', this.groupSort, GroupSort);
     this.groupAlertBehavior = AssertUtils.getValueOrDefault(
         'groupAlertBehavior', this.groupAlertBehavior, GroupAlertBehavior);
     this.icon = AssertUtils.getValueOrDefault('icon', this.icon, String);
@@ -115,7 +114,7 @@ class NotificationChannel extends Model {
 
     // For small icons, it's only allowed resource media types
     assert(StringUtils.isNullOrEmpty(icon) ||
-        BitmapUtils().getMediaSource(icon) == MediaSource.Resource);
+        BitmapUtils().getMediaSource(icon!) == MediaSource.Resource);
   }
 
   Map<String, dynamic> toMap() {
@@ -139,7 +138,8 @@ class NotificationChannel extends Model {
       'groupSort': AssertUtils.toSimpleEnumString(groupSort),
       'groupAlertBehavior': AssertUtils.toSimpleEnumString(groupAlertBehavior),
       'defaultPrivacy': AssertUtils.toSimpleEnumString(defaultPrivacy),
-      'defaultRingtoneType': AssertUtils.toSimpleEnumString(defaultRingtoneType),
+      'defaultRingtoneType':
+          AssertUtils.toSimpleEnumString(defaultRingtoneType),
       'locked': locked,
       'onlyAlertOnce': onlyAlertOnce
     };
@@ -161,8 +161,8 @@ class NotificationChannel extends Model {
         AssertUtils.extractValue(dataMap, 'vibrationPattern');
     this.enableLights = AssertUtils.extractValue(dataMap, 'enableLights');
     this.groupKey = AssertUtils.extractValue(dataMap, 'groupKey');
-    this.groupSort = AssertUtils.extractEnum(
-        dataMap, 'groupSort', GroupSort.values);
+    this.groupSort =
+        AssertUtils.extractEnum(dataMap, 'groupSort', GroupSort.values);
     this.groupAlertBehavior = AssertUtils.extractEnum(
         dataMap, 'groupAlertBehavior', GroupAlertBehavior.values);
     this.defaultPrivacy = AssertUtils.extractEnum(

--- a/lib/src/models/notification_content.dart
+++ b/lib/src/models/notification_content.dart
@@ -8,40 +8,40 @@ import 'package:flutter/material.dart';
 /// Main content of notification
 /// If notification has no [body] or [title], it will only be created, but not displayed to the user (background notification).
 class NotificationContent extends BaseNotificationContent {
-  bool hideLargeIconOnExpand;
-  int progress;
-  String ticker;
+  bool? hideLargeIconOnExpand;
+  int? progress;
+  String? ticker;
 
-  NotificationLifeCycle displayedLifeCycle;
+  NotificationLifeCycle? displayedLifeCycle;
 
-  NotificationSource createdSource;
-  NotificationLifeCycle createdLifeCycle;
+  NotificationSource? createdSource;
+  NotificationLifeCycle? createdLifeCycle;
 
-  NotificationLayout notificationLayout;
+  NotificationLayout? notificationLayout;
 
-  bool displayOnForeground;
-  bool displayOnBackground;
+  bool? displayOnForeground;
+  bool? displayOnBackground;
 
-  String createdDate;
-  String displayedDate;
+  String? createdDate;
+  String? displayedDate;
 
-  bool locked;
+  bool? locked;
 
   NotificationContent({
-      int id,
-      String channelKey,
-      String title,
-      String body,
-      String summary,
-      bool showWhen,
-      String icon,
-      String largeIcon,
-      String bigPicture,
-      String customSound,
-      bool autoCancel,
-      Color color,
-      Color backgroundColor,
-      Map<String, String> payload,
+      int? id,
+      String? channelKey,
+      String? title,
+      String? body,
+      String? summary,
+      bool? showWhen,
+      String? icon,
+      String? largeIcon,
+      String? bigPicture,
+      String? customSound,
+      bool? autoCancel,
+      Color? color,
+      Color? backgroundColor,
+      Map<String, String>? payload,
       this.notificationLayout,
       this.hideLargeIconOnExpand,
       this.locked,

--- a/lib/src/models/notification_schedule.dart
+++ b/lib/src/models/notification_schedule.dart
@@ -8,10 +8,10 @@ import 'package:awesome_notifications/src/utils/list_utils.dart';
 /// [crontabSchedule]: Crontab expression as repetition rule (with seconds precision), as described in https://www.baeldung.com/cron-expressions
 /// [allowWhileIdle]: Determines if notification will send, even when the device is in critical situation, such as low battery.
 class NotificationSchedule extends Model {
-  DateTime initialDateTime;
-  String crontabSchedule;
-  bool allowWhileIdle;
-  List<DateTime> preciseSchedules;
+  DateTime? initialDateTime;
+  String? crontabSchedule;
+  bool? allowWhileIdle;
+  List<DateTime>? preciseSchedules;
 
   NotificationSchedule(
       {this.initialDateTime,
@@ -27,13 +27,13 @@ class NotificationSchedule extends Model {
 
     if (dataMap['preciseSchedules'] != null &&
         dataMap['preciseSchedules'] is List) {
-      List<String> schedules = List<String>.from(dataMap['preciseSchedules']);
+      List<String?> schedules = List<String>.from(dataMap['preciseSchedules']);
       preciseSchedules = [];
 
-      for (String schedule in schedules) {
-        DateTime scheduleDate = DateUtils.parseStringToDate(schedule);
+      for (String? schedule in schedules) {
+        DateTime? scheduleDate = DateUtils.parseStringToDate(schedule);
         if (schedule != null) {
-          preciseSchedules.add(scheduleDate);
+          preciseSchedules!.add(scheduleDate!);
         }
       }
     }
@@ -52,9 +52,9 @@ class NotificationSchedule extends Model {
     if (!ListUtils.isNullOrEmpty(preciseSchedules)) {
       List<String> schedulesMap = [];
 
-      for (DateTime schedule in preciseSchedules) {
-        String scheduleDate = DateUtils.parseDateToString(schedule);
-        if (schedule != null) {
+      for (DateTime schedule in preciseSchedules!) {
+        String? scheduleDate = DateUtils.parseDateToString(schedule);
+        if (scheduleDate != null) {
           schedulesMap.add(scheduleDate);
         }
       }

--- a/lib/src/models/received_models/push_notification.dart
+++ b/lib/src/models/received_models/push_notification.dart
@@ -6,47 +6,48 @@ import 'package:awesome_notifications/src/models/notification_schedule.dart';
 /// Reference Model to create a new notification
 /// [schedule] and [actionButtons] are optional
 class PushNotification extends Model {
-  NotificationContent content;
-  NotificationSchedule schedule;
-  List<NotificationActionButton> actionButtons;
+  NotificationContent? content;
+  NotificationSchedule? schedule;
+  List<NotificationActionButton>? actionButtons;
 
   PushNotification({this.content, this.schedule, this.actionButtons});
 
   /// Imports data from a serializable object
-  PushNotification fromMap(Map<String, dynamic> mapData) {
+  PushNotification? fromMap(Map<String, dynamic> mapData) {
     try {
       assert(mapData.containsKey('content') && mapData['content'] is Map);
 
       Map<String, dynamic> contentData =
           Map<String, dynamic>.from(mapData['content']);
 
-      content = NotificationContent().fromMap(contentData);
-      content.validate();
+      content =
+          NotificationContent().fromMap(contentData) as NotificationContent;
+      content!.validate();
 
       if (mapData.containsKey('schedule')) {
         Map<String, dynamic> scheduleData =
             Map<String, dynamic>.from(mapData['schedule']);
 
         schedule = NotificationSchedule().fromMap(scheduleData);
-        schedule.validate();
+        schedule!.validate();
       }
 
       if (mapData.containsKey('actionButtons')) {
         actionButtons = [];
-        List<Object> actionButtonsData =
-            List<Object>.from(mapData['actionButtons']);
+        List<dynamic> actionButtonsData =
+            List<dynamic>.from(mapData['actionButtons']);
 
-        for (Object buttonData in actionButtonsData) {
+        for (dynamic buttonData in actionButtonsData) {
           Map<String, dynamic> actionButtonData =
               Map<String, dynamic>.from(buttonData);
 
-          NotificationActionButton button =
-              NotificationActionButton().fromMap(actionButtonData);
+          NotificationActionButton button = NotificationActionButton()
+              .fromMap(actionButtonData) as NotificationActionButton;
           button.validate();
 
-          actionButtons.add(button);
+          actionButtons!.add(button);
         }
-        assert(actionButtons.isNotEmpty);
+        assert(actionButtons!.isNotEmpty);
       }
     } catch (e) {
       return null;
@@ -59,9 +60,9 @@ class PushNotification extends Model {
   Map<String, dynamic> toMap() {
     List<Map<String, dynamic>> actionButtonsData = [];
     if (actionButtons != null) {
-      for (NotificationActionButton button in actionButtons) {
+      for (NotificationActionButton button in actionButtons!) {
         Map<String, dynamic> data = button.toMap();
-        if (data != null && data.isNotEmpty) actionButtonsData.add(data);
+        if (data.isNotEmpty) actionButtonsData.add(data);
       }
     }
     return {

--- a/lib/src/models/received_models/received_action.dart
+++ b/lib/src/models/received_models/received_action.dart
@@ -4,12 +4,12 @@ import 'package:awesome_notifications/src/utils/assert_utils.dart';
 
 /// All received details of a user action over a Notification
 class ReceivedAction extends ReceivedNotification {
-  NotificationLifeCycle actionLifeCycle;
-  NotificationLifeCycle dismissedLifeCycle;
+  NotificationLifeCycle? actionLifeCycle;
+  NotificationLifeCycle? dismissedLifeCycle;
   String buttonKeyPressed = '';
   String buttonKeyInput = '';
-  String actionDate;
-  String dismissedDate;
+  String? actionDate;
+  String? dismissedDate;
 
   ReceivedAction();
 

--- a/lib/src/models/received_models/received_notification.dart
+++ b/lib/src/models/received_models/received_notification.dart
@@ -6,13 +6,13 @@ import 'package:awesome_notifications/src/utils/assert_utils.dart';
 /// All received details of a notification created or displayed on the system
 /// The data field
 class ReceivedNotification extends BaseNotificationContent {
-  NotificationLifeCycle displayedLifeCycle;
+  NotificationLifeCycle? displayedLifeCycle;
 
-  NotificationSource createdSource;
-  NotificationLifeCycle createdLifeCycle;
+  NotificationSource? createdSource;
+  NotificationLifeCycle? createdLifeCycle;
 
-  String displayedDate;
-  String createdDate;
+  String? displayedDate;
+  String? createdDate;
 
   ReceivedNotification fromMap(Map<String, dynamic> dataMap) {
     super.fromMap(dataMap);

--- a/lib/src/utils/assert_utils.dart
+++ b/lib/src/utils/assert_utils.dart
@@ -4,7 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class AssertUtils {
-  static String toSimpleEnumString<T>(T e) {
+  static String? toSimpleEnumString<T>(T e) {
     if (e == null) return null;
     return e.toString().split('.')[1];
   }
@@ -23,12 +23,12 @@ class AssertUtils {
     return false;
   }
 
-  static List<Map<String, Object>> toListMap<T extends Model>(List<T> list) {
+  static List<Map<String, Object>>? toListMap<T extends Model>(List<T>? list) {
     if (list == null || list.length == 0) return null;
 
     List<Map<String, Object>> returnList = [];
     list.forEach((element) {
-      returnList.add(element.toMap());
+      returnList.add(Map<String,Object>.from(element.toMap()));
     });
 
     return returnList;
@@ -69,7 +69,7 @@ class AssertUtils {
       return defaultValue;
 
     return values.firstWhere((e) {
-      return AssertUtils.toSimpleEnumString(e).toLowerCase() ==
+      return AssertUtils.toSimpleEnumString(e)!.toLowerCase() ==
           castedValue.toLowerCase();
     }, orElse: () => defaultValue);
   }
@@ -101,13 +101,13 @@ class AssertUtils {
     return defaultValue;
   }
 
-  static fromListMap<T extends Model>(Object mapData, Function newModel) {
+  static fromListMap<T extends Model>(Object? mapData, Function newModel) {
     if (mapData == null || mapData is List<Map<String, dynamic>>) return null;
 
-    List<Map<String, dynamic>> listMapData = mapData;
+    List<Map<String, dynamic>> listMapData = List.from(mapData as List);
     if (listMapData.length <= 0) return null;
 
-    List<T> actionButtons;
+    List<T> actionButtons = [];
     listMapData.forEach((actionButtonData) {
       return actionButtons.add(newModel().fromMap(actionButtonData));
     });

--- a/lib/src/utils/date_utils.dart
+++ b/lib/src/utils/date_utils.dart
@@ -2,13 +2,13 @@ import 'package:intl/intl.dart';
 
 class DateUtils {
 
-  static DateTime parseStringToDate(String date,
+  static DateTime? parseStringToDate(String? date,
       {String format: 'yyyy-MM-dd HH:mm:ss'}) {
     if (date == null || date.isEmpty) return null;
     return DateFormat(format).parseUTC(date);
   }
 
-  static String parseDateToString(DateTime date,
+  static String? parseDateToString(DateTime? date,
       {String format: 'yyyy-MM-dd HH:mm:ss'}) {
     if (date == null) return null;
     return DateFormat(format).format(date);
@@ -17,14 +17,14 @@ class DateUtils {
   static DateTime utcToLocal(DateTime date,
       {String format: 'yyyy-MM-dd HH:mm:ss'}) {
     DateTime parsedUTCDate =
-        DateFormat(format).parseUTC(parseDateToString(date));
+        DateFormat(format).parseUTC(parseDateToString(date)!);
     return parsedUTCDate.toLocal();
   }
 
   static DateTime localToUtc(DateTime date,
       {String format: 'yyyy-MM-dd HH:mm:ss'}) {
     DateTime parsedLocalDate =
-        DateFormat(format).parse(parseDateToString(date));
+        DateFormat(format).parse(parseDateToString(date)!);
     return parsedLocalDate.toUtc();
   }
 

--- a/lib/src/utils/html_utils.dart
+++ b/lib/src/utils/html_utils.dart
@@ -1,5 +1,5 @@
 class HtmlUtils {
-  static String removeAllHtmlTags(String htmlText) {
+  static String? removeAllHtmlTags(String? htmlText) {
     if (htmlText == null) return null;
     RegExp exp =
         RegExp(r"<[a-zA-Z\/][^>]*>", multiLine: true, caseSensitive: false);

--- a/lib/src/utils/list_utils.dart
+++ b/lib/src/utils/list_utils.dart
@@ -1,5 +1,5 @@
 class ListUtils {
-  static bool isNullOrEmpty(List value) {
+  static bool isNullOrEmpty(List? value) {
     return value?.isEmpty ?? true;
   }
 }

--- a/lib/src/utils/media_abstract_utils.dart
+++ b/lib/src/utils/media_abstract_utils.dart
@@ -2,7 +2,7 @@ import 'package:awesome_notifications/src/enumerators/media_source.dart';
 import 'package:flutter/material.dart';
 
 abstract class MediaUtils {
-  MediaSource getMediaSource(String mediaPath) {
+  MediaSource getMediaSource(String? mediaPath) {
     if (mediaPath != null) {
       if (RegExp(r'^https?:\/\/').hasMatch(mediaPath)) {
         return MediaSource.Network;
@@ -24,16 +24,14 @@ abstract class MediaUtils {
   }
 
   String cleanMediaPath(String mediaPath) {
-    if (mediaPath != null) {
-      if (RegExp(r'^file:\/\/').hasMatch(mediaPath)) {
-        mediaPath = mediaPath.replaceAll('file:\/', '');
-      }
-      if (RegExp(r'^asset:\/\/').hasMatch(mediaPath)) {
-        mediaPath = mediaPath.replaceAll('asset:\/\/', '');
-      }
-      if (RegExp(r'^resource:\/\/').hasMatch(mediaPath)) {
-        mediaPath = mediaPath.replaceAll('resource:\/\/', '');
-      }
+    if (RegExp(r'^file:\/\/').hasMatch(mediaPath)) {
+      return mediaPath.replaceAll('file:\/', '');
+    }
+    if (RegExp(r'^asset:\/\/').hasMatch(mediaPath)) {
+      return mediaPath.replaceAll('asset:\/\/', '');
+    }
+    if (RegExp(r'^resource:\/\/').hasMatch(mediaPath)) {
+      return mediaPath.replaceAll('resource:\/\/', '');
     }
     return mediaPath;
   }
@@ -54,24 +52,19 @@ abstract class MediaUtils {
     switch (getMediaSource(mediaPath)) {
       case MediaSource.Asset:
         return getFromMediaAsset(mediaPath);
-        break;
 
       case MediaSource.File:
         return getFromMediaFile(mediaPath);
-        break;
 
       case MediaSource.Network:
         return getFromMediaNetwork(mediaPath);
-        break;
 
       case MediaSource.Resource:
         return getFromMediaResource(mediaPath);
-        break;
 
       case MediaSource.Unknown:
       default:
         return null;
-        break;
     }
   }
 }

--- a/lib/src/utils/resource_image_provider.dart
+++ b/lib/src/utils/resource_image_provider.dart
@@ -45,12 +45,12 @@ class ResourceImage extends ImageProvider<ResourceImage> {
 
   Future<ui.Codec> _loadAsync(ResourceImage key, DecoderCallback decode) async {
     assert(key == this);
-    Uint8List bytes;
+    Uint8List? bytes;
 
     AwesomeNotifications awesomeNotifications = AwesomeNotifications();
     bytes = await awesomeNotifications.getDrawableData(this.drawablePath);
 
-    return decode(bytes);
+    return decode(bytes!);
   }
 
   @override

--- a/lib/src/utils/string_utils.dart
+++ b/lib/src/utils/string_utils.dart
@@ -1,5 +1,5 @@
 class StringUtils {
-  static bool isNullOrEmpty(String value) {
+  static bool isNullOrEmpty(String? value) {
     return value?.isEmpty ?? true;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -157,5 +157,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.5+8
 homepage: https://github.com/rafaelsetragni/awesome_notifications
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"
 
 dependencies:

--- a/test/awesome_notifications_test.dart
+++ b/test/awesome_notifications_test.dart
@@ -6,19 +6,19 @@ void main() {
   const MethodChannel channel = MethodChannel('awesome_notifications');
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() {
-  });
+  setUp(() {});
 
-  tearDown((){
-  });
+  tearDown(() {});
 
   test('getPlatformVersion', () async {
-    DateTime referenceDate = DateUtils.parseStringToDate('2021-01-12 20:00:00');
-    DateTime expectedDate = DateUtils.parseStringToDate('2021-01-12 21:00:00');
-    NotificationSchedule schedule = NotificationSchedule(initialDateTime: expectedDate);
+    DateTime referenceDate =
+        DateUtils.parseStringToDate('2021-01-12 20:00:00')!;
+    DateTime expectedDate = DateUtils.parseStringToDate('2021-01-12 21:00:00')!;
+    NotificationSchedule schedule =
+        NotificationSchedule(initialDateTime: expectedDate);
 
-    DateTime result = await AwesomeNotifications().getNextDate(schedule, fixedDate: referenceDate);
+    DateTime result = await AwesomeNotifications()
+        .getNextDate(schedule, fixedDate: referenceDate);
     expect(result, expectedDate);
-
   });
 }


### PR DESCRIPTION
I know you have been working hard on the update, so I wanted to help where I could. I migrated the main plugin, not the example, to null-safety and I removed the FCM service for Android. I've tested this plugin along side the firebase_messaging plugin and it works flawlessly. You can set up firebase_messaging's background handler to run the following function and it will create a notification from this plugin every time you receive a push notification, even if the app has been killed. This allows use of action buttons with the flexibility of push notifications. The only thing I've been trying to figure out is how to not show the default FCM notification and only show the AwesomeNotification instead.


```
Future<dynamic> _onFCM(RemoteMessage message) async {
  WidgetsFlutterBinding.ensureInitialized();
  AwesomeNotifications().createNotification(
    content: NotificationContent(
      channelKey: "Basic",
      id: 4,
      title: message.notification?.title ?? "New Notification",
      body: message.notification?.body ?? "",
    ),
    actionButtons: [
      NotificationActionButton(
        key: 'Reply',
        label: 'Reply',
        buttonType: ActionButtonType.InputField,
      ),
    ],
  );
}
```

#97 
#128 