### PR TITLE
Read notification content fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,11 +450,15 @@ OBS: `actionButtons` and `schedule` are **optional**
 <br>
 OBS 2: you should not implement any native code to use FCM with Awesome Notifications. All of then was already implemented inside the plugin.
 <br>
+OBS 3: data only messages are classed as "low priority". Devices can throttle and ignore these messages if your application is in the background, terminated, or a variety of other conditions such as low battery or currently high CPU usage. To help improve delivery, you can bump the priority of messages. Note; this does still not guarantee delivery. More info [here](https://firebase.flutter.dev/docs/messaging/usage/#low-priority-messages)
+<br>
 
 ```json
 {
     "to" : "[YOUR APP TOKEN]",
     "mutable_content" : true,
+    "content_available": true,
+    "priority": "high",
     "data" : {
         "content": {
             "id": 100,

--- a/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
+++ b/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
@@ -276,9 +276,9 @@ public class SwiftAwesomeNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     private func receiveNotification(content:UNNotificationContent, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void){
         
         let jsonData:String? = JsonUtils.toJson([
-            "content": JsonUtils.fromJson(content.userInfo["content"] as? String),
-            "actionButtons": JsonUtils.fromJson(content.userInfo["actionButtons"] as? String),
-            "schedule": JsonUtils.fromJson(content.userInfo["schedule"] as? String)
+            Definitions.PUSH_NOTIFICATION_CONTENT: JsonUtils.fromJson(content.userInfo[Definitions.PUSH_NOTIFICATION_CONTENT] as? String),
+            Definitions.PUSH_NOTIFICATION_BUTTONS: JsonUtils.fromJson(content.userInfo[Definitions.PUSH_NOTIFICATION_BUTTONS] as? String),
+            Definitions.PUSH_NOTIFICATION_SCHEDULE: JsonUtils.fromJson(content.userInfo[Definitions.PUSH_NOTIFICATION_SCHEDULE] as? String)
         ])
         
         guard let pushNotification:PushNotification = NotificationBuilder.jsonToPushNotification(jsonData: jsonData)

--- a/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
+++ b/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
@@ -275,15 +275,30 @@ public class SwiftAwesomeNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     @available(iOS 10.0, *)
     private func receiveNotification(content:UNNotificationContent, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void){
         
-        let jsonData:String? = JsonUtils.toJson([
-            Definitions.PUSH_NOTIFICATION_CONTENT: JsonUtils.fromJson(content.userInfo[Definitions.PUSH_NOTIFICATION_CONTENT] as? String),
-            Definitions.PUSH_NOTIFICATION_BUTTONS: JsonUtils.fromJson(content.userInfo[Definitions.PUSH_NOTIFICATION_BUTTONS] as? String),
-            Definitions.PUSH_NOTIFICATION_SCHEDULE: JsonUtils.fromJson(content.userInfo[Definitions.PUSH_NOTIFICATION_SCHEDULE] as? String)
-        ])
-        
-        guard let pushNotification:PushNotification = NotificationBuilder.jsonToPushNotification(jsonData: jsonData)
+        var arguments:[String : Any?]
+        if(content.userInfo[Definitions.NOTIFICATION_JSON] != nil){
+            let jsonData:String = content.userInfo[Definitions.NOTIFICATION_JSON] as! String
+            arguments = JsonUtils.fromJson(jsonData) ?? [:]
+        }
         else {
-            Log.d("receiveNotification","notification discarted")
+            arguments = content.userInfo as! [String : Any?]
+            
+            if(arguments[Definitions.PUSH_NOTIFICATION_CONTENT] is String){
+                arguments[Definitions.PUSH_NOTIFICATION_CONTENT] = JsonUtils.fromJson(arguments[Definitions.PUSH_NOTIFICATION_CONTENT] as? String)
+            }
+            
+            if(arguments[Definitions.PUSH_NOTIFICATION_BUTTONS] is String){
+                arguments[Definitions.PUSH_NOTIFICATION_BUTTONS] = JsonUtils.fromJson(arguments[Definitions.PUSH_NOTIFICATION_BUTTONS] as? String)
+            }
+            
+            if(arguments[Definitions.PUSH_NOTIFICATION_SCHEDULE] is String){
+                arguments[Definitions.PUSH_NOTIFICATION_SCHEDULE] = JsonUtils.fromJson(arguments[Definitions.PUSH_NOTIFICATION_SCHEDULE] as? String)
+            }
+        }
+        
+        guard let pushNotification:PushNotification = NotificationBuilder.jsonDataToPushNotification(jsonData: arguments)
+        else {
+            Log.d("receiveNotification","notification data invalid")
             completionHandler([])
             return
         }

--- a/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
+++ b/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
@@ -275,7 +275,11 @@ public class SwiftAwesomeNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     @available(iOS 10.0, *)
     private func receiveNotification(content:UNNotificationContent, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void){
         
-        let jsonData:String? = content.userInfo[Definitions.NOTIFICATION_JSON] as? String
+        let jsonData:String? = JsonUtils.toJson([
+            "content": JsonUtils.fromJson(content.userInfo["content"] as? String),
+            "actionButtons": JsonUtils.fromJson(content.userInfo["actionButtons"] as? String),
+            "schedule": JsonUtils.fromJson(content.userInfo["schedule"] as? String)
+        ])
         
         guard let pushNotification:PushNotification = NotificationBuilder.jsonToPushNotification(jsonData: jsonData)
         else {

--- a/lib/src/models/notification_calendar.dart
+++ b/lib/src/models/notification_calendar.dart
@@ -8,10 +8,10 @@ class NotificationCalendar extends NotificationSchedule {
   /// Field number for get and set indicating the year.
   int? year;
 
-  /// Field number for get and set indicating the month.
+  /// Field number for get and set indicating the month of the year (1-12).
   int? month;
 
-  /// Field number for get and set indicating the day number within the current year (1-12).
+  /// Field number for get and set indicating the day number of the month (1-31).
   int? day;
 
   /// Field number for get and set indicating the hour of the day (0-23).
@@ -26,7 +26,7 @@ class NotificationCalendar extends NotificationSchedule {
   /// Field number for get and set indicating the millisecond within the second.
   int? millisecond;
 
-  /// Field number for get and set indicating the day of the week.
+  /// Field number for get and set indicating the day of the week .
   int? weekday;
 
   /// Field number for get and set indicating the count of weeks of the month.


### PR DESCRIPTION
Needs the `content_available` key when sending to iOS token. Android stills working.

Included `priority` key to high to increase the default priority based on this [doc](https://firebase.flutter.dev/docs/messaging/usage/#low-priority-messages).

Readme updated.

```json
{
    "to" : "{{fcm_token}}",
    "mutable_content" : true,
    "content_available": true,
    "priority": "high",
    "data" : {
        "content": {
            "id": 100,
            "channelKey": "big_picture",
            "title": "Huston!\nThe eagle has landed!",
            "body": "A small step for a man, but a giant leap to Flutter's community!",
            "notificationLayout": "BigPicture",
            "largeIcon": "https://media.fstatic.com/kdNpUx4VBicwDuRBnhBrNmVsaKU=/full-fit-in/290x478/media/artists/avatar/2013/08/neil-i-armstrong_a39978.jpeg",
            "bigPicture": "https://www.dw.com/image/49519617_303.jpg",
            "showWhen": true,
            "autoCancel": true,
            "privacy": "Private"
        },
        "actionButtons": [
            {
                "key": "REPLY",
                "label": "Reply",
                "autoCancel": true,
                "buttonType":  "InputField"
            },
            {
                "key": "ARCHIVE",
                "label": "Archive",
                "autoCancel": true
            }
        ],
        "schedule": {
            "hour": "10",
            "minute": "0",
            "second": "0",
            "allowWhileIdle": true,
            "repeat": true
        }
    }
}
```