### PR TITLE
Guava '-android' should be used to avoid conflicts with other packages.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ allprojects {
 dependencies {
     implementation "androidx.core:core:1.3.1"
     implementation "com.google.code.gson:gson:2.8.5"
-    implementation "com.google.guava:guava:30.1-jre"
+    implementation "com.google.guava:guava:30.1-android"
     implementation "com.android.support:support-v4:28.0.0"
     implementation "com.github.arturogutierrez:badges:1.0.5@aar"
 


### PR DESCRIPTION
Fixed Guava lib conflict, check Issue #230 for details.