### PR TITLE
Prevents AwesomeNotifications from clobbering any existing UNNotificationCategory objects

### DIFF
--- a/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
+++ b/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
@@ -693,7 +693,10 @@ public class SwiftAwesomeNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                 intentIdentifiers: [],
                 options: .customDismissAction
             )
-            UNUserNotificationCenter.current().setNotificationCategories([categoryObject])
+
+            UNUserNotificationCenter.current().getNotificationCategories(completionHandler: { results in
+                UNUserNotificationCenter.current().setNotificationCategories(results.union([categoryObject]))
+            })
         }
         
         SwiftAwesomeNotificationsPlugin.appLifeCycle = NotificationLifeCycle.AppKilled

--- a/ios/Classes/lib/notifications/NotificationBuilder.swift
+++ b/ios/Classes/lib/notifications/NotificationBuilder.swift
@@ -402,7 +402,7 @@ public class NotificationBuilder {
                 intentIdentifiers: [],
                 options: .customDismissAction
             )
-            // UNUserNotificationCenter.current().setNotificationCategories([categoryObject])
+            
             UNUserNotificationCenter.current().getNotificationCategories(completionHandler: { results in
                 UNUserNotificationCenter.current().setNotificationCategories(results.union([categoryObject]))
             })

--- a/ios/Classes/lib/notifications/NotificationBuilder.swift
+++ b/ios/Classes/lib/notifications/NotificationBuilder.swift
@@ -402,7 +402,10 @@ public class NotificationBuilder {
                 intentIdentifiers: [],
                 options: .customDismissAction
             )
-            UNUserNotificationCenter.current().setNotificationCategories([categoryObject])
+            // UNUserNotificationCenter.current().setNotificationCategories([categoryObject])
+            UNUserNotificationCenter.current().getNotificationCategories(completionHandler: { results in
+                UNUserNotificationCenter.current().setNotificationCategories(results.union([categoryObject]))
+            })
         }
     }
     


### PR DESCRIPTION
I ran into an issue where I had created UNNotificationCategory objects for remote Notification Messages, and found that AwesomeNotifications clobbers these definitions when creating custom action buttons locally.  This change modifies the setCategories call to use `Set` union operations to prevent clobbering.

Without being able to see `UNNotificationCategory`'s source code, there remains a small possibility that its `hashValue` function is not implemented in a way that would allow this to function properly.  As such, this still needs a bit of testing to be sure that this does not simply create a bunch of excess `UNNotificationCategory` objects (a new one each time a notification w/ custom action buttons is created)...