### PR TITLE
Fix README FCM example schedule type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,9 +1105,9 @@ OBS 4: Again, the background message method of the `firebase_messaging` plug-in 
         ],
         "schedule": {
             "timeZone": "America/New_York",
-            "hour": 10,
-            "minute": 0,
-            "second": 0,
+            "hour": "10",
+            "minute": "0",
+            "second": "0",
             "allowWhileIdle": true,
             "repeat": true
         }

--- a/README.md
+++ b/README.md
@@ -1105,9 +1105,9 @@ OBS 4: Again, the background message method of the `firebase_messaging` plug-in 
         ],
         "schedule": {
             "timeZone": "America/New_York",
-            "hour": "10",
-            "minute": "0",
-            "second": "0",
+            "hour": 10,
+            "minute": 0,
+            "second": 0,
             "allowWhileIdle": true,
             "repeat": true
         }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.18+1"
+    version: "0.6.18+2"
   boolean_selector:
     dependency: transitive
     description:

--- a/test/extraction_values_test.dart
+++ b/test/extraction_values_test.dart
@@ -1,0 +1,73 @@
+import 'package:awesome_notifications/awesome_notifications.dart';
+import 'package:flutter/material.dart' hide DateUtils;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {});
+
+  tearDown(() {});
+
+  test('extractValueTest', () async {
+    expect("title", AssertUtils.extractValue("test", {"test": "title"}, String));
+    expect(" title", AssertUtils.extractValue("test", {"test": " title"}, String));
+    expect("", AssertUtils.extractValue("test", {"test": ""}, String));
+    expect(" ", AssertUtils.extractValue("test", {"test": " "}, String));
+
+    expect(10, AssertUtils.extractValue("test", {"test": "10"}, int));
+    expect(10, AssertUtils.extractValue("test", {"test": 10}, int));
+    expect(10, AssertUtils.extractValue("test", {"test": "10.0"}, int));
+    expect(10.0, AssertUtils.extractValue("test", {"test": "10.0"}, double));
+    expect(0, AssertUtils.extractValue("test", {"test": "0"}, int));
+    expect(0.0, AssertUtils.extractValue("test", {"test": "0"}, double));
+    expect(0, AssertUtils.extractValue("test", {"test": "0.0"}, int));
+    expect(0, AssertUtils.extractValue("test", {"test": 0}, int));
+
+    expect(0xFFFF0000, AssertUtils.extractValue("test", {"test": "#FF0000"}, int));
+    expect(0xFFFF0000, AssertUtils.extractValue("test", {"test": "#ff0000"}, int));
+    expect(0xFFFF0000, AssertUtils.extractValue("test", {"test": "#FFFF0000"}, int));
+    expect(0x00FF0000, AssertUtils.extractValue("test", {"test": "#00FF0000"}, int));
+    expect(0xFFFF0000, AssertUtils.extractValue("test", {"test": "0xFF0000"}, int));
+    expect(0xFFFF0000, AssertUtils.extractValue("test", {"test": "0xFFff0000"}, int));
+
+    expect(Colors.black, AssertUtils.extractValue("test", {"test": "#000000"}, Color));
+    expect(Colors.black, AssertUtils.extractValue("test", {"test": "#FF000000"}, Color));
+    expect(Colors.transparent, AssertUtils.extractValue("test", {"test": "#00000000"}, Color));
+
+    expect(null, AssertUtils.extractValue("test", {"test": null}, Color));
+    expect(null, AssertUtils.extractValue("test", {"test": "#0004"}, Color));
+    expect(null, AssertUtils.extractValue("test", {"test": "#04"}, Color));
+    expect(null, AssertUtils.extractValue("test", {"test": " "}, Color));
+
+    expect(null, AssertUtils.extractValue("test", {"test": null}, int));
+    expect(null, AssertUtils.extractValue("test", {"test": ""}, int));
+    expect(null, AssertUtils.extractValue("test", {"test": " "}, int));
+
+    expect(null, AssertUtils.extractValue("test", {"test": 0}, String));
+    expect(null, AssertUtils.extractValue("test", {"test": null}, String));
+  });
+
+  test('extractEnumTest', () async {
+    expect(NotificationPrivacy.Private,
+        AssertUtils.extractEnum<NotificationPrivacy>(
+            "test", {"test": "Private"}, NotificationPrivacy.values));
+
+    expect(NotificationPrivacy.Public,
+        AssertUtils.extractEnum<NotificationPrivacy>(
+            "test", {"test": "Public"}, NotificationPrivacy.values));
+
+    expect(null,
+        AssertUtils.extractEnum<NotificationPrivacy>(
+            "test", {"test": ""}, NotificationPrivacy.values));
+
+    expect(null,
+        AssertUtils.extractEnum<NotificationPrivacy>(
+            "test", {"test": " "}, NotificationPrivacy.values));
+
+    expect(null,
+        AssertUtils.extractEnum<NotificationPrivacy>(
+            "test", {"test": null}, NotificationPrivacy.values));
+  });
+
+}


### PR DESCRIPTION
I found that the schedule hour/minute/second in the json example, will never work because `AssertUtils.extractValue` seems to be designed to handle color code instead of converting string to int, so I changed hour/minute/second to int type to make it work. second to int type to make it work

```dart
this.hour =
        AssertUtils.extractValue(NOTIFICATION_SCHEDULE_HOUR, dataMap, int);
    this.minute =
        AssertUtils.extractValue(NOTIFICATION_SCHEDULE_MINUTE, dataMap, int);
    this.second =
        AssertUtils.extractValue(NOTIFICATION_SCHEDULE_SECOND, dataMap, int);
```

```dart
  static extractValue<T>(String reference, Map dataMap, Type T) {
    dynamic defaultValue = _getDefaultValue(reference, T);
    dynamic value = dataMap[reference];

    // Color hexadecimal representation
    if (T == int && value != null && value is String) {
      String valueCasted = value;

      final RegExpMatch? match =
          RegExp(r'^(0x|#)(\w{2})?(\w{6,6})$').firstMatch(valueCasted);
      if (match != null) {
        String hex = (match.group(2) ?? 'FF') + match.group(3)!;
        final int colorValue = int.parse(hex, radix: 16);
        return colorValue;
      }
    }

    switch (value.runtimeType) {
      case MaterialColor:
        value = (value as MaterialColor).shade500;
        break;

      case MaterialAccentColor:
        value = Color((value as MaterialAccentColor).value);
        break;

      case CupertinoDynamicColor:
        value = Color((value as CupertinoDynamicColor).value);
        break;
    }

    if (value == null || !(value.runtimeType == T)) return defaultValue;

    return value;
  }
```