### PR TITLE
Fix: typo in README initialize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,26 +146,24 @@ import 'package:awesome_notifications/awesome_notifications.dart';
 
 ```dart
 AwesomeNotifications().initialize(
-    // set the icon to null if you want to use the default app icon
-    'resource://drawable/res_app_icon',
-    [
-        NotificationChannel(
-            channelGroupKey: 'basic_channel_group',
-            channelKey: 'basic_channel',
-            channelName: 'Basic notifications',
-            channelDescription: 'Notification channel for basic tests',
-            defaultColor: Color(0xFF9D50DD),
-            ledColor: Colors.white
-        ),
-    ],
-    // Channel groups are only visual and are not required
-    channelGroups: [
-      NotificationChannelGroup(
+  // set the icon to null if you want to use the default app icon
+  'resource://drawable/res_app_icon',
+  [
+    NotificationChannel(
+        channelGroupKey: 'basic_channel_group',
+        channelKey: 'basic_channel',
+        channelName: 'Basic notifications',
+        channelDescription: 'Notification channel for basic tests',
+        defaultColor: Color(0xFF9D50DD),
+        ledColor: Colors.white)
+  ],
+  // Channel groups are only visual and are not required
+  channelGroups: [
+    NotificationChannelGroup(
         channelGroupkey: 'basic_channel_group',
-        channelGroupName: 'Basic group'
-      )
-    ],
-    debug: true
+        channelGroupName: 'Basic group')
+  ],
+  debug: true
 );
 ```
 


### PR DESCRIPTION
The example provided in the initialize section was incorrect, mostly bracket misalignment.