### PR TITLE
Fixed Compatibility issue with flutter 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.6.22]
+* Bumped `platform` dependency to 3.1.0 to support Flutter 2.10.0+
 ## [0.6.21]
 * Added customSound feature for Android (only applicable for versions older than Android 8 (Oreo))
 * Type parameter T removed for AwessomeAssertUtils to allows it to be compatible with Flutter web parser.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: awesome_notifications
 description: A complete solution to create Local Notifications and Push Notifications (Media Notifications, Big Picture, Big text, etc), through Firebase or another services, using Flutter.
-version: 0.6.21
+version: 0.6.22
 homepage: https://github.com/rafaelsetragni/awesome_notifications
 
 environment:
@@ -17,7 +17,7 @@ dependencies:
   #meta: ^1.3.0
   #rxdart: any
   
-  platform: ^3.0.2
+  platform: 3.1.0
   intl: ^0.17.0
 
 dev_dependencies:


### PR DESCRIPTION
`platform` 3.0.2 uses a deprecated member that was [removed in flutter 2.10.0](https://github.com/google/platform.dart/pull/38)