### PR TITLE
Fixes zeros being saved instead of the actual handles

### DIFF
--- a/android/src/main/java/me/carda/awesome_notifications/core/models/DefaultsModel.java
+++ b/android/src/main/java/me/carda/awesome_notifications/core/models/DefaultsModel.java
@@ -52,8 +52,8 @@ public class DefaultsModel extends AbstractModel {
         Map<String, Object> dataMap = new HashMap<>();
 
         putDataOnSerializedMap(Definitions.NOTIFICATION_APP_ICON, dataMap, appIcon);
-        putDataOnSerializedMap(Definitions.SILENT_HANDLE, dataMap, "0");
-        putDataOnSerializedMap(Definitions.BACKGROUND_HANDLE, dataMap, "0");
+        putDataOnSerializedMap(Definitions.SILENT_HANDLE, dataMap, silentDataCallback);
+        putDataOnSerializedMap(Definitions.BACKGROUND_HANDLE, dataMap, reverseDartCallback);
         putDataOnSerializedMap(Definitions.NOTIFICATION_BG_HANDLE_CLASS, dataMap, backgroundHandleClass);
 
         return dataMap;


### PR DESCRIPTION
### Fixes

Zeros being saved in shared preferences instead of the actual handles. This resulted in the app unable to call it's handlers after being terminated.

### Sugested tests

- Create a notification with an action (and it's action handler), terminate the app, and click on the action. Even when the action handler is created correctly, AwesomeNotifications kept receiving "0" as the handler.