### PR TITLE
Sync some mismatched definitions in dart and swift code

### DIFF
--- a/android/src/main/java/me/carda/awesome_notifications/core/Definitions.java
+++ b/android/src/main/java/me/carda/awesome_notifications/core/Definitions.java
@@ -42,7 +42,7 @@ public interface Definitions {
 
     String ACTION_HANDLE = "actionHandle";
     String SILENT_HANDLE = "silentHandle";
-    String BACKGROUND_HANDLE = "bgHandle";
+    String BACKGROUND_HANDLE = "awesomeDartBGHandle";
 
     String SCHEDULER_HELPER_SHARED = "awnot.sh.";
     String SCHEDULER_HELPER_ALL = "all";

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -43,8 +43,8 @@ const CHANNEL_FLUTTER_PLUGIN = 'awesome_notifications';
 const DART_REVERSE_CHANNEL = 'awesome_notifications_reverse';
 
 const ACTION_HANDLE = 'actionHandle';
-const BACKGROUND_HANDLE = 'bgHandle';
-const RECOVER_DISPLAYED = 'recoverDisplayed';
+const BACKGROUND_HANDLE = 'awesomeDartBGHandle';
+const RECOVER_DISPLAYED = 'recoverScheduledDisplayed';
 
 const CHANNEL_METHOD_INITIALIZE = 'initialize';
 const CHANNEL_METHOD_PUSH_NEXT_DATA = 'pushNext';


### PR DESCRIPTION
**Fixes**
The Swift plugin can't read `BACKGROUND_HANDLE` and `RECOVER_DISPLAYED` parameters from Flutter because they are mismatched with those defined in Swift. This resulted in the iOS app being unable to call its handlers after being terminated and throw this exception instead `A background message could not be handled in Dart because there is no valid background handler register`

**Suggesteded tests**
Open app on iOS device, create a notification with an action (and its action handler), terminate the app, and click on the action.