### PR TITLE
Added lifecycle status change check listener for iOS.

### DIFF
--- a/ios/Classes/lib/core/managers/LifeCycleManager.swift
+++ b/ios/Classes/lib/core/managers/LifeCycleManager.swift
@@ -34,6 +34,10 @@ public class LifeCycleManager:
     
     var _listening = false
     public func startListeners(){
+        if _listening {
+            return
+        }
+
         _listening = true
         
         NotificationCenter.default.addObserver(


### PR DESCRIPTION
Added lifecycle status change check listener for iOS. This fixes the wrong lifecycle status bug if the application uses isolates.