### PR TITLE
Fix Android reboot non-repeating notification rescheduling

### DIFF
--- a/example/android/awn_core/src/main/java/me/carda/awesome_notifications/core/models/NotificationScheduleModel.java
+++ b/example/android/awn_core/src/main/java/me/carda/awesome_notifications/core/models/NotificationScheduleModel.java
@@ -28,11 +28,15 @@ public abstract class NotificationScheduleModel extends AbstractModel {
 
     @NonNull
     public NotificationScheduleModel fromMap(Map<String, Object> arguments) {
+        CalendarUtils calendarUtils = CalendarUtils.getInstance();
         timeZone       = getValueOrDefault(arguments, Definitions.NOTIFICATION_SCHEDULE_TIMEZONE, TimeZone.class, TimeZone.getDefault());
         createdDate    = getValueOrDefault(arguments, Definitions.NOTIFICATION_CREATED_DATE, Calendar.class, null);
         repeats        = getValueOrDefault(arguments, Definitions.NOTIFICATION_SCHEDULE_REPEATS, Boolean.class, false);
         allowWhileIdle = getValueOrDefault(arguments, Definitions.NOTIFICATION_ALLOW_WHILE_IDLE, Boolean.class, false);
         preciseAlarm   = getValueOrDefault(arguments, Definitions.NOTIFICATION_SCHEDULE_PRECISE_ALARM, Boolean.class, false);
+        createdDate    = calendarUtils.calendarFromString(
+            getValueOrDefault(arguments, Definitions.NOTIFICATION_CREATED_DATE, String.class, null)
+        );
 
         return this;
     }

--- a/lib/src/models/notification_schedule.dart
+++ b/lib/src/models/notification_schedule.dart
@@ -16,7 +16,7 @@ abstract class NotificationSchedule extends Model {
       this.repeats = false,
       this.preciseAlarm = false});
 
-  DateTime? _createdDate;
+  DateTime? _createdDate = DateTime.now();
 
   /// Reference
   DateTime? get createdDate => _createdDate;

--- a/lib/src/models/notification_schedule.dart
+++ b/lib/src/models/notification_schedule.dart
@@ -1,3 +1,4 @@
+import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:awesome_notifications/src/models/model.dart';
 import 'package:awesome_notifications/src/utils/assert_utils.dart';
 
@@ -15,10 +16,10 @@ abstract class NotificationSchedule extends Model {
       this.repeats = false,
       this.preciseAlarm = false});
 
-  String? _createdDate;
+  DateTime? _createdDate;
 
   /// Reference
-  String? get createdDate => _createdDate;
+  DateTime? get createdDate => _createdDate;
 
   /// Full time zone identifier to schedule a notification, in english (ex: America/Sao_Paulo, America/New_York, Europe/Helsinki or GMT-07:00)
   String timeZone;
@@ -51,6 +52,10 @@ abstract class NotificationSchedule extends Model {
             NOTIFICATION_SCHEDULE_PRECISE_ALARM, mapData, bool) ??
         false;
 
+    _createdDate = AwesomeDateUtils.parseStringToDate(
+        AwesomeAssertUtils.extractValue(
+            NOTIFICATION_CREATED_DATE, mapData, String));
+
     return this;
   }
 
@@ -60,7 +65,8 @@ abstract class NotificationSchedule extends Model {
       NOTIFICATION_SCHEDULE_TIMEZONE: timeZone,
       NOTIFICATION_ALLOW_WHILE_IDLE: allowWhileIdle,
       NOTIFICATION_SCHEDULE_REPEATS: repeats,
-      NOTIFICATION_SCHEDULE_PRECISE_ALARM: preciseAlarm
+      NOTIFICATION_SCHEDULE_PRECISE_ALARM: preciseAlarm,
+      NOTIFICATION_CREATED_DATE: AwesomeDateUtils.parseDateToString(createdDate),
     };
 
     return dataMap;


### PR DESCRIPTION
Previously the hasNextValidDate() method of the NotificationScheduleModel.java class would always return false for non reoccurring notifications, this is because the fromMap() method of the NotificationScheduleModel.java always populates the createdDate variable with null. This has been fixed by:
- Changing notification_schedule.dart _createdDate to a DateTime from a String
- Including a string converted date in the toMap() method of notification_schedule.dart
- Reading string in as calendar in the NotificationScheduleModel.java fromMap() method.

Also updated:
-notification_schedule.dart fromMap() method now includes createdDate as well.