### PR TITLE
Add namespace for compatibility to AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty('namespace')) {
+        namespace 'me.carda.awesome_notifications'
+    }
     compileSdkVersion 33
 
     compileOptions {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'me.carda.awesome_notifications_example'
     compileSdkVersion 33 //flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/example/lib/utils/common_functions.dart
+++ b/example/lib/utils/common_functions.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:flutter/material.dart';
-import 'package:device_info/device_info.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 
 Future<String> saveAssetOnDisk(ImageProvider image, String fileName) async {

--- a/example/lib/utils/common_web_functions.dart
+++ b/example/lib/utils/common_web_functions.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:flutter/material.dart';
-import 'package:device_info/device_info.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 
 Future<String> saveAssetOnDisk(ImageProvider image, String fileName) async {

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,12 +6,14 @@ import FlutterMacOS
 import Foundation
 
 import awesome_notifications
+import device_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AwesomeNotificationsPlugin.register(with: registry.registrar(forPlugin: "AwesomeNotificationsPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -104,22 +104,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  device_info:
+  device_info_plus:
     dependency: "direct main"
     description:
-      name: device_info
-      sha256: f4a8156cb7b7480d969cb734907d18b333c8f0bc0b1ad0b342cdcecf30d62c48
+      name: device_info_plus
+      sha256: "2c35b6d1682b028e42d07b3aee4b98fa62996c10bc12cb651ec856a80d6a761b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
-  device_info_platform_interface:
+    version: "9.0.2"
+  device_info_plus_platform_interface:
     dependency: transitive
     description:
-      name: device_info_platform_interface
-      sha256: b148e0bf9640145d09a4f8dea96614076f889e7f7f8b5ecab1c7e5c2dbc73c1b
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "7.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -620,6 +620,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.4"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "1c52f994bdccb77103a6231ad4ea331a244dbcef5d1f37d8462f713143b0bfae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   numberpicker: ^2.1.2
   giff_dialog: ^1.0.1
   vibration: ^1.7.7
-  device_info: ^2.0.3
+  device_info_plus: ^9.0.2
   url_launcher: ^6.1.11
   intl: ^0.18.1
   palette_generator: ^0.3.3+2


### PR DESCRIPTION
Define namespace in build.gradle to be compatible with AGP 8.

I had to migrate to device_info_plus, because device_info is not maintained anymore.
