### PR TITLE
Add PlaybackState support in Android

### DIFF
--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -282,6 +282,9 @@ const NOTIFICATION_TICKER = 'ticker';
 const NOTIFICATION_ALLOW_WHILE_IDLE = 'allowWhileIdle';
 const NOTIFICATION_ROUNDED_LARGE_ICON = 'roundedLargeIcon';
 const NOTIFICATION_ROUNDED_BIG_PICTURE = 'roundedBigPicture';
+const NOTIFICATION_DURATION = 'duration';
+const NOTIFICATION_PLAY_STATE = 'playState';
+const NOTIFICATION_PLAYBACK_SPEED = 'playbackSpeed';
 
 class Definitions {
   static Map<String, Object?> initialValues = {
@@ -325,3 +328,35 @@ class Definitions {
     NOTIFICATION_ROUNDED_BIG_PICTURE: false,
   };
 }
+
+/*
+  State of PlaybackStateCompat
+  https://developer.android.com/reference/kotlin/android/support/v4/media/session/PlaybackStateCompat
+ */
+/// This is the default playback state and indicates that no media has been added yet, or the performer has been reset and has no content to play.
+const PLAY_STATE_NONE = 0;
+/// State indicating this item is currently stopped.
+const PLAY_STATE_STOPPED = 1;
+/// State indicating this item is currently paused.
+const PLAY_STATE_PAUSED = 2;
+/// State indicating this item is currently playing.
+const PLAY_STATE_PLAYING = 3;
+/// State indicating this item is currently fast forwarding.
+const PLAY_STATE_FAST_FORWARDING = 4;
+/// State indicating this item is currently rewinding.
+const PLAY_STATE_REWINDING = 5;
+/// State indicating this item is currently buffering and will begin playing when enough data has buffered.
+const PLAY_STATE_BUFFERING = 6;
+/// State indicating this item is currently in an error state. The error code should also be set when entering this state.
+const PLAY_STATE_ERROR = 7;
+/// State indicating the class doing playback is currently connecting to a route. Depending on the implementation you may return to the previous state when the connection finishes or enter STATE_NONE. If the connection failed STATE_ERROR should be used.
+/// On devices earlier than API 21, this will appear as STATE_BUFFERING
+const PLAY_STATE_CONNECTING = 8;
+/// State indicating the player is currently skipping to the previous item.
+const PLAY_STATE_SKIPPING_TO_PREVIOUS = 9;
+/// State indicating the player is currently skipping to the next item.
+const PLAY_STATE_SKIPPING_TO_NEXT = 10;
+/// State indicating the player is currently skipping to a specific item in the queue.
+const PLAY_STATE_SKIPPING_TO_QUEUE_ITEM = 11;
+/// Use this value for the position to indicate the position is not known.
+const PLAY_PLAYBACK_POSITION_UNKNOWN = -1;

--- a/lib/src/models/notification_content.dart
+++ b/lib/src/models/notification_content.dart
@@ -11,8 +11,9 @@ import 'base_notification_content.dart';
 /// If notification has no [body] or [title], it will only be created, but not displayed to the user (background notification).
 class NotificationContent extends BaseNotificationContent {
   bool? _hideLargeIconOnExpand;
-  int? _progress, _badge;
+  int? _progress, _badge, _duration, _playState;
   String? _ticker;
+  double? _playbackSpeed;
 
   NotificationLayout? _notificationLayout;
 
@@ -53,6 +54,18 @@ class NotificationContent extends BaseNotificationContent {
     return _locked;
   }
 
+  int? get duration {
+    return _duration;
+  }
+
+  int? get playState {
+    return _playState;
+  }
+
+  double? get playbackSpeed {
+    return _playbackSpeed;
+  }
+
   NotificationContent(
       {required int id,
       required String channelKey,
@@ -85,7 +98,10 @@ class NotificationContent extends BaseNotificationContent {
       int? badge,
       String? ticker,
       bool displayOnForeground = true,
-      bool displayOnBackground = true})
+      bool displayOnBackground = true,
+      int? duration,
+      int? playState,
+      double? playbackSpeed})
       : _hideLargeIconOnExpand = hideLargeIconOnExpand,
         _progress = progress,
         _ticker = ticker,
@@ -94,6 +110,9 @@ class NotificationContent extends BaseNotificationContent {
         _displayOnForeground = displayOnForeground,
         _displayOnBackground = displayOnBackground,
         _locked = locked,
+        _duration = duration,
+        _playState = playState,
+        _playbackSpeed = playbackSpeed,
         super(
             id: id,
             channelKey: channelKey,
@@ -133,6 +152,12 @@ class NotificationContent extends BaseNotificationContent {
         AwesomeAssertUtils.extractValue<String>(NOTIFICATION_TICKER, mapData);
     _locked =
         AwesomeAssertUtils.extractValue<bool>(NOTIFICATION_LOCKED, mapData);
+    _duration =
+        AwesomeAssertUtils.extractValue<int>(NOTIFICATION_DURATION, mapData);
+    _playState =
+        AwesomeAssertUtils.extractValue<int>(NOTIFICATION_PLAY_STATE, mapData);
+    _playbackSpeed =
+        AwesomeAssertUtils.extractValue<double>(NOTIFICATION_PLAYBACK_SPEED, mapData);
 
     _notificationLayout = AwesomeAssertUtils.extractEnum<NotificationLayout>(
         NOTIFICATION_LAYOUT, mapData, NotificationLayout.values);
@@ -166,6 +191,9 @@ class NotificationContent extends BaseNotificationContent {
         NOTIFICATION_LAYOUT: _notificationLayout?.name,
         NOTIFICATION_DISPLAY_ON_FOREGROUND: _displayOnForeground,
         NOTIFICATION_DISPLAY_ON_BACKGROUND: _displayOnBackground,
+        NOTIFICATION_DURATION: _duration,
+        NOTIFICATION_PLAY_STATE: _playState,
+        NOTIFICATION_PLAYBACK_SPEED: _playbackSpeed,
       });
     return dataMap;
   }


### PR DESCRIPTION
Related PR: https://github.com/rafaelsetragni/AndroidAwnCore/pull/1

To support PlaybackState, the following properties are added to `NotificationContent`:
- `duration`, int, media duration in milliseconds
- `playState`, int, same as PlaybackState.STATE_XXX(see https://developer.android.com/reference/android/media/session/PlaybackState)
- `playbackSpeed`, double, literal meaning, playback speed