### PR TITLE
Remove references to v1 embedding

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -314,7 +314,7 @@
       "languageVersion": "2.19"
     }
   ],
-  "generated": "2024-03-16T00:49:39.723613Z",
+  "generated": "2024-03-17T12:33:44.911585Z",
   "generator": "pub",
   "generatorVersion": "3.3.1"
 }

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -13,9 +13,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="90f153b2-27cc-4b8f-8201-8a3571b86189" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.dart_tool/package_config.json" beforeDir="false" afterPath="$PROJECT_DIR$/.dart_tool/package_config.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/CHANGELOG.md" beforeDir="false" afterPath="$PROJECT_DIR$/CHANGELOG.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pubspec.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/pubspec.yaml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -86,7 +86,7 @@
     "cidr.known.project.marker": "true",
     "com.intellij.openapi.externalSystem.service.settings.ExternalSystemGroupConfigurable": "ALL",
     "dart.analysis.tool.window.visible": "false",
-    "git-widget-placeholder": "development",
+    "git-widget-placeholder": "master",
     "io.flutter.reload.alreadyRun": "true",
     "last_opened_file_path": "/Users/rafaelsetragni/GitHub/plugins/awesome_notifications",
     "run.code.analysis.last.selected.profile": "pProject Default",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.9.3+1] - 2024-07-06
+## [0.9.3+2] - 2024-07-06
 ### Removes references to Flutter v1 android embedding classes.
 
 ## [0.9.3+1] - 2024-15-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.9.3+1] - 2024-15-03
+### Transition Support from Github to Discord Community
+- **GitHub Issues Closure**: Effective immediately, GitHub issues will no longer be open for new support requests. Existing issues will remain accessible as an archive and resource.
+- **Discord Community Support**: All support for Awesome Notifications has transitioned to our Discord community. This move aims to provide a more dynamic, interactive, and efficient support experience.
+- **Reasons for Change**:
+  - *Community Rules Respect*: Numerous issues posted on GitHub have not adhered to our community guidelines, impacting heavily on support efficiency and effectiveness.
+  - *Efficiency and Effectiveness*: Managing support through GitHub has become exceedingly time-consuming, particularly when posts omit critical information or disregard guidelines.
+  - *Quality of Support*: Our Discord community allows for real-time engagement, resource sharing, and a closer-knit user and developer interaction, which wasn't true for GitHub.
+- **Next Steps for Users**: We encourage all users to join our Discord community [https://discord.awesome-notifications.carda.me/](https://discord.awesome-notifications.carda.me/) for ongoing support, updates, and to connect with fellow users and the development team.
+
 ## [0.9.3] - 2024-15-03
 ### Added
 - **Double Check in Lost Events Manager:** Implemented a double-check for `createdDate` and `displayedDate` fields to enhance the stability of the Awesome Notifications framework.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.9.3+1] - 2024-07-06
+### Removes references to Flutter v1 android embedding classes.
+
 ## [0.9.3+1] - 2024-15-03
 ### Transition Support from Github to Discord Community
 - **GitHub Issues Closure**: Effective immediately, GitHub issues will no longer be open for new support requests. Existing issues will remain accessible as an archive and resource.

--- a/README.md
+++ b/README.md
@@ -1561,7 +1561,6 @@ Here's an example of how to add these properties to your `AndroidManifest.xml` f
    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
    <application
-        android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="Awesome Notifications for Flutter">
         <activity

--- a/android/src/main/java/me/carda/awesome_notifications/AwesomeNotificationsPlugin.java
+++ b/android/src/main/java/me/carda/awesome_notifications/AwesomeNotificationsPlugin.java
@@ -19,7 +19,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import me.carda.awesome_notifications.core.AwesomeNotifications;
 import me.carda.awesome_notifications.core.Definitions;
 import me.carda.awesome_notifications.core.completion_handlers.BitmapCompletionHandler;
@@ -106,21 +105,6 @@ public class AwesomeNotificationsPlugin
     private AwesomeNotifications awesomeNotifications;
 
     private final StringUtils stringUtils = StringUtils.getInstance();
-
-    // https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration
-    // FOR OLDER FLUTTER VERSIONS (1.11 releases and bellow)
-    public static void registerWith(Registrar registrar) {
-
-        AwesomeNotificationsPlugin awesomeNotificationsPlugin
-                = new AwesomeNotificationsPlugin();
-
-        awesomeNotificationsPlugin.AttachAwesomeNotificationsPlugin(
-                registrar.context(),
-                new MethodChannel(
-                        registrar.messenger(),
-                        Definitions.CHANNEL_FLUTTER_PLUGIN
-                ));
-    }
 
     // FOR NEWER FLUTTER VERSIONS (1.12 releases and above)
     @Override

--- a/android/src/main/java/me/carda/awesome_notifications/FlutterBitmapUtils.java
+++ b/android/src/main/java/me/carda/awesome_notifications/FlutterBitmapUtils.java
@@ -9,7 +9,7 @@ import android.os.Build;
 
 import java.io.InputStream;
 
-import io.flutter.view.FlutterMain;
+import io.flutter.FlutterInjector;
 import me.carda.awesome_notifications.core.utils.BitmapUtils;
 
 public class FlutterBitmapUtils extends BitmapUtils {
@@ -43,7 +43,9 @@ public class FlutterBitmapUtils extends BitmapUtils {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 inputStream = context.getAssets().open("flutter_assets/" + bitmapPath);
             } else {
-                String assetLookupKey = FlutterMain.getLookupKeyForAsset(bitmapPath);
+                String assetLookupKey = FlutterInjector.instance()
+                        .flutterLoader()
+                        .getLookupKeyForAsset(bitmapPath);
                 AssetManager assetManager = context.getAssets();
                 AssetFileDescriptor assetFileDescriptor = assetManager.openFd(assetLookupKey);
                 inputStream = assetFileDescriptor.createInputStream();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: awesome_notifications
 description: A complete solution to create Local and Push Notifications, customizing buttons, images, sounds, emoticons and applying many different layouts for Flutter apps.
-version: 0.9.3+1
+version: 0.9.3+2
 repository: https://github.com/rafaelsetragni/awesome_notifications
 homepage: https://discord.awesome-notifications.carda.me/
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: awesome_notifications
 description: A complete solution to create Local and Push Notifications, customizing buttons, images, sounds, emoticons and applying many different layouts for Flutter apps.
-version: 0.9.3
+version: 0.9.3+1
 repository: https://github.com/rafaelsetragni/awesome_notifications
+homepage: https://discord.awesome-notifications.carda.me/
 
 environment:
   sdk: '>=2.19.0 <4.0.0'


### PR DESCRIPTION
Fixes https://github.com/rafaelsetragni/awesome_notifications/issues/953.

We were not able to build the example app, because this plugin appears to require 3.19 due to changes in the `TextTheme` class - so this is a best effort removal, but not verified to build with https://github.com/flutter/engine/pull/52022/.

Searched for the removed classes with https://github.com/search?q=repo%3Arafaelsetragni%2Fawesome_notifications+%28%22io.flutter.view.FlutterMain%22+OR+%22io.flutter.view.FlutterNativeView%22+OR+%22io.flutter.view.FlutterView%22+OR+%22io.flutter.embedding.engine.plugins.shim%22+OR+%22io.flutter.app%22+OR+%22PluginRegistry.Registrar%22%29&type=code.
