### PR TITLE
Update README with updated iOS setup for background actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,7 +740,7 @@ To avoid this, you need to add the following lines to the `AppDelegate.swift` fi
 ```Swift
 import Flutter
 import awesome_notifications
-import shared_preferences_ios
+import shared_preferences_foundation
 //import all_other_plugins_that_i_need
 
 override func application(
@@ -750,10 +750,10 @@ override func application(
       GeneratedPluginRegistrant.register(with: self)
 
       // This function registers the desired plugins to be used within a notification background action
-      SwiftAwesomeNotificationsPlugin.setPluginRegistrantCallback { registry in          
+      SwiftAwesomeNotificationsPlugin.setPluginRegistrantCallback { registry in
           SwiftAwesomeNotificationsPlugin.register(
-            with: registry.registrar(forPlugin: "io.flutter.plugins.awesomenotifications.AwesomeNotificationsPlugin")!)          
-          FLTSharedPreferencesPlugin.register(
+            with: registry.registrar(forPlugin: "io.flutter.plugins.awesomenotifications.AwesomeNotificationsPlugin")!)
+          SharedPreferencesPlugin.register(
             with: registry.registrar(forPlugin: "io.flutter.plugins.sharedpreferences.SharedPreferencesPlugin")!)
       }
 


### PR DESCRIPTION
I'm seeing this error:
```
[Swift Compiler Error (Xcode): No such module 'shared_preferences_ios' - Flutter](https://stackoverflow.com/questions/75264268/swift-compiler-error-xcode-no-such-module-shared-preferences-ios-flutter)
```

When following the step in https://pub.dev/packages/awesome_notifications#-extra-ios-setup-for-background-actions
The change in this PR should fix that error. See: https://stackoverflow.com/a/75295094/1790381