### PR TITLE
Update awesome_notifications.dart

### DIFF
--- a/lib/awesome_notifications.dart
+++ b/lib/awesome_notifications.dart
@@ -73,8 +73,8 @@ Int64List highVibrationPattern =
 
 class AwesomeNotifications implements IAwesomeNotifications {
   static int get maxID => 2147483647;
-  static String localTimeZoneIdentifier = 'UTC';
-  static String utcTimeZoneIdentifier = DateTime.now().timeZoneName;
+  static String localTimeZoneIdentifier = DateTime.now().timeZoneName;
+  static String utcTimeZoneIdentifier = 'UTC';
 
   @override
   Future<void> cancel(int id) {


### PR DESCRIPTION
I've modified the timezone identifiers: utc to 'UTC', and local to 'now().timeZoneName'.

I noticed that notifications sometimes appear +9 hours after the set time. Since +9 hours corresponds to KST, which is also my timezone, it seems that the set time is not accounting for the timezone.

Upon reviewing the code, I found that the variable names and values do not align.

While I have not analyzed the entire project code, in this segment, I suggest adjustments to better reflect the variable names.
Could you please review this PR and confirm if the original implementation was indeed correct?

Thank you for your project.