### PR TITLE
fix: set internal broadcast receivers to exported=false

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,13 +6,13 @@
     <application>
 
         <receiver android:name=".DartNotificationActionReceiver"
-            android:exported="true"/>
+            android:exported="false"/>
 
         <receiver android:name=".DartDismissedNotificationReceiver"
-            android:exported="true"/>
+            android:exported="false"/>
 
         <receiver android:name=".DartScheduledNotificationReceiver"
-            android:exported="true"/>
+            android:exported="false"/>
 
         <receiver
             android:name=".DartRefreshSchedulesReceiver"


### PR DESCRIPTION
## Summary

- Sets `android:exported="false"` for three internal broadcast receivers that do not declare intent-filters:
  - `DartNotificationActionReceiver`
  - `DartDismissedNotificationReceiver`
  - `DartScheduledNotificationReceiver`
- `DartRefreshSchedulesReceiver` is **not** modified — it requires `exported="true"` to receive system broadcasts (`BOOT_COMPLETED`, `LOCKED_BOOT_COMPLETED`, etc.)

## Problem

These three receivers are internal components that handle notification actions, dismissals, and scheduled triggers from within the app process. They are currently declared with `android:exported="true"` but do not have intent-filters, meaning any app on the device can send arbitrary intents to them.

This allows a malicious app to:
- Trigger notification dismiss events
- Inject attacker-controlled JSON payloads into the Dart notification handler
- Force dismissal of displayed notifications

**References:**
- [CWE-926: Improper Export of Android Application Components](https://cwe.mitre.org/data/definitions/926.html)
- OWASP Mobile Top 10: M8 - Security Misconfiguration

## Test plan

- [ ] Verify local notifications still trigger `DartNotificationActionReceiver` on tap
- [ ] Verify scheduled notifications still fire via `DartScheduledNotificationReceiver`
- [ ] Verify notification dismissal callbacks still work via `DartDismissedNotificationReceiver`
- [ ] Verify boot receiver (`DartRefreshSchedulesReceiver`) still reschedules notifications after reboot
- [ ] Verify that external apps can no longer send intents to the three fixed receivers