### PR TITLE
fix(ios): Critical Alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,6 +1313,17 @@ To enable critical alerts, you need to add the `ACCESS_NOTIFICATION_POLICY` perm
 </manifest>
 ```
 
+#### iOS Critical Alerts (optional)
+
+Critical alerts on iOS are **opt-in** and require Apple's explicit approval. Apps without the entitlement continue to work normally; critical flags are ignored and notifications are delivered with standard interruption levels.
+
+1. Request the `com.apple.developer.usernotifications.critical-alerts` entitlement from Apple and add it to your **Runner** target. If you use FCM with a Notification Service Extension, add the same entitlement to the **extension** target as well.
+2. Register a channel with `criticalAlerts: true` and/or set `criticalAlert: true` on `NotificationContent`.
+3. Request `NotificationPermission.CriticalAlert` explicitly via `requestPermissionToSendNotifications`.
+4. For FCM, include `mutable_content: true` and the Awesome notification payload with the correct `channelKey`.
+
+Apps without Apple's entitlement can still declare `criticalAlerts` on channels; the plugin degrades gracefully to standard notification delivery.
+
 In summary, if you need to ensure precise execution of scheduled notifications, make sure to use the appropriate categories and properties for your notifications, and enable the necessary permissions in your app's manifest file.
 
 Additionally, you can ask your users to whitelist your app from any battery optimization feature that the device may have. This can be done by adding your app to the "unmonitored apps" or "battery optimization exceptions" list, depending on the device.
@@ -1331,7 +1342,7 @@ To know more about it, please visit [flutter_background_service_fetch documentat
 3. If you're running your app in debug mode, all schedules may be erased by the Android OS when you close the app. This ensures consistent behavior when testing in debug mode. To test schedule notifications on Android when the app is not running, make sure to open the app without debugging.
 4. If your app doesn't require precise scheduling of notifications, avoid requesting exact notifications to conserve battery life.
 5. Categorize your notifications correctly to avoid scheduling delays.
-6. Note that critical alerts are still under development and should not be used in production mode.
+6. On iOS, critical alerts require Apple's entitlement and user permission. Without them, notifications fall back to standard delivery without errors.
 
 <br>
 

--- a/example/ios/Runner/Runner.entitlements
+++ b/example/ios/Runner/Runner.entitlements
@@ -6,5 +6,9 @@
 	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array/>
+	<!-- Optional: only if Apple approved critical alerts for your app
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
+	-->
 </dict>
 </plist>

--- a/example/lib/notifications/notifications_util.dart
+++ b/example/lib/notifications/notifications_util.dart
@@ -324,6 +324,24 @@ class NotificationUtils {
     }
   }
 
+  static Future<void> showCriticalAlertNotification(int id) async {
+    try {
+      bool success = await AwesomeNotifications().createNotification(
+          content: NotificationContent(
+              id: id,
+              channelKey: 'scheduled',
+              title: 'Critical Alert',
+              body: 'This notification uses the critical alert channel and content flag',
+              criticalAlert: true,
+              playSound: true,
+              wakeUpScreen: true));
+
+      debugPrint(success ? 'Critical notification created successfully' : '');
+    } on PlatformException catch (exception) {
+      debugPrint('$exception');
+    }
+  }
+
   static Future<void> showNotificationFromJson(
       Map<String, Object> jsonData) async {
     await AwesomeNotifications().createNotificationFromJsonData(jsonData);

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -34,6 +34,7 @@ class _HomePageState extends State<HomePage> {
   bool globalNotificationsAllowed = false;
   bool schedulesFullControl = false;
   bool isCriticalAlertsEnabled = false;
+  bool isCriticalAlertsNotSupported = false;
   bool isPreciseAlarmEnabled = false;
   bool isOverrideDnDEnabled = false;
 
@@ -138,14 +139,21 @@ class _HomePageState extends State<HomePage> {
 
   void refreshDangerousChannelPermissions() {
     AwesomeNotifications()
-        .checkPermissionList(permissions: dangerousPermissions)
-        .then((List<NotificationPermission> permissionsAllowed) => setState(() {
+        .getPermissionStatusList(permissions: dangerousPermissions)
+        .then((Map<NotificationPermission, NotificationPermissionStatus>
+            permissionStatuses) => setState(() {
               for (NotificationPermission permission in dangerousPermissions) {
+                final NotificationPermissionStatus status =
+                    permissionStatuses[permission] ??
+                        NotificationPermissionStatus.denied;
                 dangerousPermissionsStatus[permission] =
-                    permissionsAllowed.contains(permission);
+                    status == NotificationPermissionStatus.granted;
               }
               isCriticalAlertsEnabled = dangerousPermissionsStatus[
                   NotificationPermission.CriticalAlert]!;
+              isCriticalAlertsNotSupported =
+                  permissionStatuses[NotificationPermission.CriticalAlert] ==
+                      NotificationPermissionStatus.notSupported;
               isPreciseAlarmEnabled = dangerousPermissionsStatus[
                   NotificationPermission.PreciseAlarms]!;
               isOverrideDnDEnabled = dangerousPermissionsStatus[
@@ -322,12 +330,18 @@ class _HomePageState extends State<HomePage> {
                               refreshPermissionsIcons();
                             }))),
             SimpleButton('Request Critical Alerts mode',
-                enabled: !isCriticalAlertsEnabled,
+                enabled: !isCriticalAlertsEnabled && !isCriticalAlertsNotSupported,
                 onPressed: () =>
                     NotificationUtils.requestCriticalAlertsPermission(context)
                         .then((isAllowed) => setState(() {
                               refreshPermissionsIcons();
                             }))),
+            if (isCriticalAlertsNotSupported)
+              const TextNote(
+                  'Critical Alerts are not supported on this device or project. '
+                  'Add the Apple critical-alerts entitlement to enable them on iOS.'),
+            SimpleButton('Show critical alert notification (iOS/Android)',
+                onPressed: () => NotificationUtils.showCriticalAlertNotification(9001)),
             SimpleButton('Request to Override Do not Disturb mode (Android)',
                 enabled: !isOverrideDnDEnabled,
                 onPressed: () =>

--- a/ios/AwnCore/Classes/Definitions.swift
+++ b/ios/AwnCore/Classes/Definitions.swift
@@ -97,6 +97,7 @@ public enum Definitions {
     public static let  CHANNEL_METHOD_IS_NOTIFICATION_ALLOWED = "isNotificationAllowed"
     public static let  CHANNEL_METHOD_REQUEST_NOTIFICATIONS = "requestNotifications"
     public static let  CHANNEL_METHOD_CHECK_PERMISSIONS = "checkPermissions"
+    public static let  CHANNEL_METHOD_GET_PERMISSION_STATUSES = "getPermissionStatuses"
     public static let  CHANNEL_METHOD_SHOULD_SHOW_RATIONALE = "shouldShowRationale"
 
     public static let  CHANNEL_METHOD_DISMISS_NOTIFICATION = "dismissNotification"
@@ -190,6 +191,7 @@ public enum Definitions {
     public static let  NOTIFICATION_ENABLED = "enabled"
     public static let  NOTIFICATION_AUTO_DISMISSIBLE = "autoDismissible"
     public static let  NOTIFICATION_LOCKED = "locked"
+    public static let  NOTIFICATION_CRITICAL_ALERT = "criticalAlert"
     public static let  NOTIFICATION_DISPLAY_ON_FOREGROUND = "displayOnForeground"
     public static let  NOTIFICATION_DISPLAY_ON_BACKGROUND = "displayOnBackground"
     public static let  NOTIFICATION_ICON = "icon"

--- a/ios/AwnCore/Classes/builders/NotificationBuilder.swift
+++ b/ios/AwnCore/Classes/builders/NotificationBuilder.swift
@@ -161,7 +161,7 @@ public class NotificationBuilder {
                 content: content)
         
         setWakeUpScreen(notificationModel: notificationModel, content: content)
-        setCriticalAlert(channel: channel, content: content)
+        setCriticalAlert(channel: channel, notificationModel: notificationModel, content: content)
         
         setUserInfoContent(notificationModel: notificationModel, content: content)
         
@@ -460,7 +460,34 @@ public class NotificationBuilder {
     }
 
     private func setSound(notificationModel:NotificationModel, channel:NotificationChannelModel, content:UNMutableNotificationContent){
-        
+        let criticalRequested = CriticalAlertUtils.isCriticalAlertRequested(
+            channel: channel,
+            notificationModel: notificationModel)
+
+        if criticalRequested && CriticalAlertUtils.canDeliverCriticalAlerts() {
+            if (notificationModel.content!.playSound ?? false) && (channel.playSound ?? false) {
+                if #available(iOS 12.0, *) {
+                    if !StringUtils.shared.isNullOrEmpty(notificationModel.content!.customSound) {
+                        content.sound = AudioUtils.shared.getSoundFromSource(
+                            SoundPath: notificationModel.content!.customSound!)
+                        return
+                    }
+
+                    if !StringUtils.shared.isNullOrEmpty(channel.soundSource) {
+                        content.sound = AudioUtils.shared.getSoundFromSource(
+                            SoundPath: channel.soundSource!)
+                        return
+                    }
+
+                    content.sound = UNNotificationSound.defaultCritical
+                    return
+                }
+            } else {
+                content.sound = nil
+            }
+            return
+        }
+
         switch notificationModel.importance ?? .Default {
             
             case .Default, .High, .Max:
@@ -522,11 +549,23 @@ public class NotificationBuilder {
         }
     }
     
-    private func setCriticalAlert(channel:NotificationChannelModel, content:UNMutableNotificationContent){
-        if channel.criticalAlerts ?? false {
-            if #available(iOS 15.0, *) {
-                content.interruptionLevel = .critical
-            }
+    private func setCriticalAlert(
+        channel: NotificationChannelModel,
+        notificationModel: NotificationModel,
+        content: UNMutableNotificationContent
+    ){
+        let requested = CriticalAlertUtils.isCriticalAlertRequested(
+            channel: channel,
+            notificationModel: notificationModel)
+        guard requested else { return }
+
+        guard CriticalAlertUtils.canDeliverCriticalAlerts() else {
+            Logger.d(TAG, "Critical alert requested but not available; using standard delivery")
+            return
+        }
+
+        if #available(iOS 15.0, *) {
+            content.interruptionLevel = .critical
         }
     }
 

--- a/ios/AwnCore/Classes/enumerators/NotificationPermissionStatus.swift
+++ b/ios/AwnCore/Classes/enumerators/NotificationPermissionStatus.swift
@@ -1,0 +1,10 @@
+public enum NotificationPermissionStatus : String, CaseIterable {
+    case granted = "granted"
+    case denied = "denied"
+    case notDetermined = "notDetermined"
+    case notSupported = "notSupported"
+
+    static func fromString(_ label: String) -> NotificationPermissionStatus? {
+        return self.allCases.first { "\($0)" == label }
+    }
+}

--- a/ios/AwnCore/Classes/managers/PermissionManager.swift
+++ b/ios/AwnCore/Classes/managers/PermissionManager.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import UserNotifications
+
 
 typealias ActivityCompletionHandler = () -> ()
 
@@ -82,6 +84,7 @@ public class PermissionManager {
         
         let current = UNUserNotificationCenter.current()
         current.getNotificationSettings(completionHandler: { (settings) in
+            CriticalAlertUtils.updateCache(from: settings)
             
             if settings.authorizationStatus == .notDetermined {
                 // The user hasnt decided yet if he authorizes or not
@@ -97,7 +100,22 @@ public class PermissionManager {
                 // Notification permission was already granted
                 permissionCompletion(true)
                 return
+
+            } else if #available(iOS 12.0, *) {
+                if settings.authorizationStatus == .provisional {
+                    permissionCompletion(true)
+                    return
+                }
             }
+
+            if #available(iOS 14.0, *) {
+                if settings.authorizationStatus == .ephemeral {
+                    permissionCompletion(true)
+                    return
+                }
+            }
+
+            permissionCompletion(false)
         })
         
         //return UIApplication.shared.isRegisteredForRemoteNotifications
@@ -118,6 +136,7 @@ public class PermissionManager {
             }
             
             UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { iOSpermissions in
+                CriticalAlertUtils.updateCache(from: iOSpermissions)
                 
                 for permission in permissions {
                     if let permissionEnum:NotificationPermission = NotificationPermission.fromString(permission) {
@@ -149,7 +168,8 @@ public class PermissionManager {
                             case .OverrideDnD: fallthrough
                             case .CriticalAlert:
                                 if #available(iOS 12.0, *) {
-                                    if(iOSpermissions.criticalAlertSetting == .disabled){
+                                    if iOSpermissions.criticalAlertSetting != .enabled &&
+                                        iOSpermissions.criticalAlertSetting != .notSupported {
                                         shouldShowRationaleList.append(NotificationPermission.CriticalAlert.rawValue)
                                     }
                                 }
@@ -190,6 +210,7 @@ public class PermissionManager {
             }
             
             UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { iOSpermissions in
+                CriticalAlertUtils.updateCache(from: iOSpermissions)
                 
                 // (Settings != .Disabled == .Enabled & .NotSupported /*Emulator limitations*/)
                 for permission in permissions {
@@ -276,6 +297,7 @@ public class PermissionManager {
     public func isSpecifiedPermissionGloballyAllowed(_ permission:String, channel:String?, completion: @escaping (Bool) -> ()){
 
         UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { iOSpermissions in
+            CriticalAlertUtils.updateCache(from: iOSpermissions)
             
             // (Settings != .Disabled == .Enabled & .NotSupported /*Emulator limitations*/)
             switch NotificationPermission.fromString(permission) {
@@ -365,6 +387,211 @@ public class PermissionManager {
         return false
     }
 
+    public func getPermissionStatuses(
+        _ permissions:[String],
+        filteringByChannelKey channelKey:String?,
+        whenGotResults completion: @escaping ([String:String]) -> ()
+    ) {
+        if SwiftUtils.isRunningOnExtension() {
+            var statuses:[String:String] = [:]
+            for permission in permissions {
+                statuses[permission] = NotificationPermissionStatus.granted.rawValue
+            }
+            completion(statuses)
+            return
+        }
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            CriticalAlertUtils.updateCache(from: settings)
+
+            var statuses:[String:String] = [:]
+            for permission in permissions {
+                statuses[permission] = self.resolvePermissionStatus(
+                    permission: permission,
+                    settings: settings,
+                    channelKey: channelKey)
+            }
+            completion(statuses)
+        }
+    }
+
+    private func resolvePermissionStatus(
+        permission:String,
+        settings:UNNotificationSettings,
+        channelKey:String?
+    ) -> String {
+        guard let permissionEnum = NotificationPermission.fromString(permission) else {
+            return NotificationPermissionStatus.notSupported.rawValue
+        }
+
+        switch permissionEnum {
+            case .CriticalAlert, .OverrideDnD:
+                return resolveCriticalAlertPermissionStatus(settings: settings)
+
+            case .Alert:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.alertSetting)
+
+            case .Sound:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.soundSetting)
+
+            case .Badge:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.badgeSetting)
+
+            case .Car:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.carPlaySetting)
+
+            case .Provisional:
+                if #available(iOS 12.0, *) {
+                    if settings.authorizationStatus == .provisional {
+                        return NotificationPermissionStatus.granted.rawValue
+                    }
+                    if settings.authorizationStatus == .notDetermined {
+                        return NotificationPermissionStatus.notDetermined.rawValue
+                    }
+                    if settings.authorizationStatus == .denied {
+                        return NotificationPermissionStatus.denied.rawValue
+                    }
+                    return NotificationPermissionStatus.notDetermined.rawValue
+                }
+                return NotificationPermissionStatus.notSupported.rawValue
+
+            default:
+                if channelKey == nil ||
+                    isSpecifiedChannelPermissionAllowed(
+                        channelKey: channelKey!,
+                        permissionEnum: permissionEnum) {
+                    return NotificationPermissionStatus.granted.rawValue
+                }
+                return NotificationPermissionStatus.denied.rawValue
+        }
+    }
+
+    private func resolveNotificationSettingStatus(
+        settings:UNNotificationSettings,
+        setting:UNNotificationSetting
+    ) -> String {
+        if settings.authorizationStatus == .notDetermined {
+            return NotificationPermissionStatus.notDetermined.rawValue
+        }
+        if settings.authorizationStatus == .denied {
+            return NotificationPermissionStatus.denied.rawValue
+        }
+        switch setting {
+            case .enabled:
+                return NotificationPermissionStatus.granted.rawValue
+            case .notSupported:
+                return NotificationPermissionStatus.notSupported.rawValue
+            default:
+                return NotificationPermissionStatus.denied.rawValue
+        }
+    }
+
+    @available(iOS 12.0, *)
+    private func resolveCriticalAlertPermissionStatus(
+        settings:UNNotificationSettings
+    ) -> String {
+        switch settings.criticalAlertSetting {
+            case .enabled:
+                return NotificationPermissionStatus.granted.rawValue
+            case .notSupported:
+                if self.isBaseNotificationAuthorizationGranted(settings) {
+                    return NotificationPermissionStatus.notDetermined.rawValue
+                }
+                return NotificationPermissionStatus.notSupported.rawValue
+            default:
+                break
+        }
+
+        if settings.authorizationStatus == .notDetermined {
+            return NotificationPermissionStatus.notDetermined.rawValue
+        }
+        if settings.authorizationStatus == .denied {
+            return NotificationPermissionStatus.denied.rawValue
+        }
+        return NotificationPermissionStatus.notDetermined.rawValue
+    }
+
+    private func isBaseNotificationAuthorizationGranted(_ settings: UNNotificationSettings) -> Bool {
+        if #available(iOS 12.0, *) {
+            return settings.authorizationStatus == .authorized ||
+                settings.authorizationStatus == .provisional
+        }
+        return settings.authorizationStatus == .authorized
+    }
+
+    @available(iOS 12.0, *)
+    private func isCriticalAlertEntitlementMissing(_ settings: UNNotificationSettings) -> Bool {
+        return settings.criticalAlertSetting == .notSupported &&
+            !isBaseNotificationAuthorizationGranted(settings)
+    }
+
+    @available(iOS 12.0, *)
+    private func shouldRequestCriticalAlertAuthorization(_ settings: UNNotificationSettings) -> Bool {
+        if settings.criticalAlertSetting == .disabled {
+            return true
+        }
+        if settings.criticalAlertSetting == .notSupported &&
+            isBaseNotificationAuthorizationGranted(settings) {
+            return true
+        }
+        return false
+    }
+
+    private func iosCriticalAlertAuthorizationPermissions() -> [String] {
+        return [
+            NotificationPermission.Alert.rawValue,
+            NotificationPermission.Sound.rawValue,
+            NotificationPermission.Badge.rawValue,
+            NotificationPermission.CriticalAlert.rawValue
+        ]
+    }
+
+    private func requestCriticalAlertPermissionIfNeeded(
+        permissionsNeeded:[String],
+        permissionsRequested:[String],
+        settings:UNNotificationSettings,
+        channelKey:String?,
+        permissionCompletion: @escaping ([String]) -> ()
+    ) -> Bool {
+        guard #available(iOS 12.0, *) else { return false }
+
+        let needsCriticalAlertPermission =
+            permissionsRequested.contains(NotificationPermission.CriticalAlert.rawValue) ||
+            permissionsRequested.contains(NotificationPermission.OverrideDnD.rawValue)
+
+        guard needsCriticalAlertPermission else { return false }
+        guard isBaseNotificationAuthorizationGranted(settings) else { return false }
+        guard settings.criticalAlertSetting != .enabled else { return false }
+
+        if self.isCriticalAlertEntitlementMissing(settings) {
+            Logger.e(self.TAG,
+                "Critical Alerts are not available for this project. " +
+                "You must require Apple special permissions to use it. " +
+                "For more informations, please read our official documentation.")
+            permissionCompletion(permissionsNeeded)
+            return true
+        }
+
+        if self.shouldRequestCriticalAlertAuthorization(settings) {
+            self.showRequestDialog(
+                channelKey: nil,
+                permissionsNeeded: permissionsNeeded,
+                permissionsToRequest: self.iosCriticalAlertAuthorizationPermissions(),
+                permissionCompletion: permissionCompletion)
+            return true
+        }
+
+        return false
+    }
+
     public func requestUserPermissions(
         _ permissions:[String],
         filteringByChannelKey channelKey:String?,
@@ -392,6 +619,7 @@ public class PermissionManager {
                 
                 else {
                     UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+                        CriticalAlertUtils.updateCache(from: settings)
                         
                         var isAllowed:Bool = false
                         if #available(iOS 12.0, *) {
@@ -406,7 +634,7 @@ public class PermissionManager {
                         if #available(iOS 12.0, *) {
                             if permissionsRequested.contains(NotificationPermission.CriticalAlert.rawValue) ||
                                 permissionsRequested.contains(NotificationPermission.OverrideDnD.rawValue){
-                                if(settings.criticalAlertSetting == .notSupported){
+                                if self.isCriticalAlertEntitlementMissing(settings) {
                                     Logger.e(self.TAG,
                                         "Critical Alerts are not available for this project. " +
                                         "You must require Apple special permissions to use it. " +
@@ -416,7 +644,7 @@ public class PermissionManager {
                                         return
                                     }
                                     permissionsRequested = permissionsRequested.filter {
-                                        ![NotificationPermission.CriticalAlert.rawValue, NotificationPermission.CriticalAlert.rawValue].contains($0)
+                                        ![NotificationPermission.CriticalAlert.rawValue, NotificationPermission.OverrideDnD.rawValue].contains($0)
                                     }
                                 }
                             }
@@ -424,6 +652,15 @@ public class PermissionManager {
                         
                         if permissionsRequested.isEmpty {
                             permissionCompletion(permissions)
+                            return
+                        }
+
+                        if self.requestCriticalAlertPermissionIfNeeded(
+                            permissionsNeeded: permissionsNeeded,
+                            permissionsRequested: permissionsRequested,
+                            settings: settings,
+                            channelKey: channelKey,
+                            permissionCompletion: permissionCompletion) {
                             return
                         }
 
@@ -440,7 +677,7 @@ public class PermissionManager {
                             
                             if listToShowRationale.count == 1 {
                                 
-                                guard let permissionEnum = NotificationPermission.fromString(permissionsNeeded.first!) else {
+                                guard let permissionEnum = NotificationPermission.fromString(listToShowRationale.first!) else {
                                     self.refreshReturnedPermissions(
                                         permissionsNeeded,
                                         filteringByChannelKey: channelKey,
@@ -453,11 +690,11 @@ public class PermissionManager {
                                     case .OverrideDnD: fallthrough
                                     case .CriticalAlert:
                                         if #available(iOS 12.0, *) {
-                                            if(settings.criticalAlertSetting == .disabled){
+                                            if self.shouldRequestCriticalAlertAuthorization(settings) {
                                                 self.showRequestDialog(
-                                                    channelKey: channelKey,
+                                                    channelKey: nil,
                                                     permissionsNeeded: permissionsNeeded,
-                                                    permissionsToRequest: listToShowRationale,
+                                                    permissionsToRequest: self.iosCriticalAlertAuthorizationPermissions(),
                                                     permissionCompletion: permissionCompletion)
                                                 return
                                             }
@@ -498,6 +735,7 @@ public class PermissionManager {
         
         let iOSpermissions:UNAuthorizationOptions = getIosPermissionsCode(permissionsToRequest)
         UNUserNotificationCenter.current().requestAuthorization(options: iOSpermissions) { (granted, error) in
+            CriticalAlertUtils.clearCache()
 
             if granted {
                 Logger.d("PermissionManager", "Permissions enabled successfully")
@@ -621,18 +859,25 @@ public class PermissionManager {
 
     public func startTestedActivity(_ url:String) -> Bool {
 
-        guard let settingsUrl = URL(string: url) else {
+        guard
+            let settingsUrl = URL(string: url),
+            let application = SwiftUtils.sharedApplication()
+        else {
             return false
         }
-        
-        if UIApplication.shared.canOpenURL(settingsUrl) {
-            DispatchQueue.main.async {
-                UIApplication.shared.open(settingsUrl)
-            }
-            return true
+
+        // `open(_:)` is unavailable in app extensions, so it is dispatched through the
+        // Objective-C runtime to keep this file compiling under `-application-extension`.
+        // This is an app-only action and is never reached from an app extension.
+        let openSelector = NSSelectorFromString("openURL:")
+        guard application.responds(to: openSelector) else {
+            return false
         }
-        
-        return false
+
+        DispatchQueue.main.async {
+            application.perform(openSelector, with: settingsUrl)
+        }
+        return true
     }
     public func handlePermissionResult() {
         fireActivityCompletionHandle()

--- a/ios/AwnCore/Classes/models/NotificationChannelModel.swift
+++ b/ios/AwnCore/Classes/models/NotificationChannelModel.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public class NotificationChannelModel : AbstractModel {
     
+    public static let TAG = "NotificationChannelModel"
+    
     public var channelKey: String?
     var channelName: String?
     var channelDescription: String?
@@ -44,44 +46,50 @@ public class NotificationChannelModel : AbstractModel {
     
     public init(){}
     
-    public func fromMap(arguments: [String : Any?]?) -> AbstractModel? {
+    public convenience init?(fromMap arguments:[String : Any?]?) {
+        if arguments?.isEmpty ?? true { return nil }
         
-        self.channelKey         = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_KEY, arguments: arguments)
-        self.channelName        = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_NAME, arguments: arguments)
-        self.channelDescription = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_DESCRIPTION, arguments: arguments)
-        self.channelShowBadge   = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_SHOW_BADGE, arguments: arguments)
-        
-        self.playSound          = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_PLAY_SOUND, arguments: arguments)
-        self.soundSource        = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_SOUND_SOURCE, arguments: arguments)
-        
-        self.enableVibration    = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_ENABLE_VIBRATION, arguments: arguments)
-        self.vibrationPattern   = MapUtils<[Int]>.getValueOrDefault(reference: Definitions.NOTIFICATION_VIBRATION_PATTERN, arguments: arguments)
-        
-        self.enableLights       = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_ENABLE_LIGHTS, arguments: arguments)
-        self.ledColor           = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_LED_COLOR, arguments: arguments)
-        self.ledOnMs            = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_LED_ON_MS, arguments: arguments)
-        self.ledOffMs           = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_LED_OFF_MS, arguments: arguments)
-        
-        self.icon               = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_ICON, arguments: arguments)
-        self.defaultColor       = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_DEFAULT_COLOR, arguments: arguments)
-        
-        self.importance         = EnumUtils<NotificationImportance>.getEnumOrDefault(reference: Definitions.NOTIFICATION_IMPORTANCE, arguments: arguments)
-        
-        self.groupSort          = EnumUtils<GroupSort>.getEnumOrDefault(reference: Definitions.NOTIFICATION_GROUP_SORT, arguments: arguments)
-        self.groupKey           = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_GROUP_KEY, arguments: arguments)
-        
-        self.locked             = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_LOCKED, arguments: arguments)
-        self.onlyAlertOnce      = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_ONLY_ALERT_ONCE, arguments: arguments)
+        do {
+            self.init()
+            self.channelKey         = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_KEY, arguments: arguments)
+            self.channelName        = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_NAME, arguments: arguments)
+            self.channelDescription = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_DESCRIPTION, arguments: arguments)
+            self.channelShowBadge   = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_SHOW_BADGE, arguments: arguments)
+            
+            self.playSound          = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_PLAY_SOUND, arguments: arguments)
+            self.soundSource        = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_SOUND_SOURCE, arguments: arguments)
+            
+            self.enableVibration    = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_ENABLE_VIBRATION, arguments: arguments)
+            self.vibrationPattern   = MapUtils<[Int]>.getValueOrDefault(reference: Definitions.NOTIFICATION_VIBRATION_PATTERN, arguments: arguments)
+            
+            self.enableLights       = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_ENABLE_LIGHTS, arguments: arguments)
+            self.ledColor           = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_LED_COLOR, arguments: arguments)
+            self.ledOnMs            = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_LED_ON_MS, arguments: arguments)
+            self.ledOffMs           = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_LED_OFF_MS, arguments: arguments)
+            
+            self.icon               = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_ICON, arguments: arguments)
+            self.defaultColor       = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_DEFAULT_COLOR, arguments: arguments)
+            
+            self.importance         = EnumUtils<NotificationImportance>.getEnumOrDefault(reference: Definitions.NOTIFICATION_IMPORTANCE, arguments: arguments)
+            
+            self.groupSort          = EnumUtils<GroupSort>.getEnumOrDefault(reference: Definitions.NOTIFICATION_GROUP_SORT, arguments: arguments)
+            self.groupKey           = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_GROUP_KEY, arguments: arguments)
+            
+            self.locked             = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_LOCKED, arguments: arguments)
+            self.onlyAlertOnce      = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_ONLY_ALERT_ONCE, arguments: arguments)
 
-        self.criticalAlerts     = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_CRITICAL_ALERTS, arguments: arguments)
+            self.criticalAlerts     = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_CHANNEL_CRITICAL_ALERTS, arguments: arguments)
 
-        self.defaultPrivacy     = EnumUtils<NotificationPrivacy>.getEnumOrDefault(reference: Definitions.NOTIFICATION_DEFAULT_PRIVACY, arguments: arguments)
+            self.defaultPrivacy     = EnumUtils<NotificationPrivacy>.getEnumOrDefault(reference: Definitions.NOTIFICATION_DEFAULT_PRIVACY, arguments: arguments)
 
-        self.groupAlertBehavior = EnumUtils<GroupAlertBehaviour>.getEnumOrDefault(reference: Definitions.NOTIFICATION_GROUP_ALERT_BEHAVIOR, arguments: arguments)
-        
-        self.defaultRingtoneType = EnumUtils<DefaultRingtoneType>.getEnumOrDefault(reference: Definitions.NOTIFICATION_DEFAULT_RINGTONE_TYPE, arguments: arguments)
-        
-        return self
+            self.groupAlertBehavior = EnumUtils<GroupAlertBehaviour>.getEnumOrDefault(reference: Definitions.NOTIFICATION_GROUP_ALERT_BEHAVIOR, arguments: arguments)
+            
+            self.defaultRingtoneType = EnumUtils<DefaultRingtoneType>.getEnumOrDefault(reference: Definitions.NOTIFICATION_DEFAULT_RINGTONE_TYPE, arguments: arguments)
+        }
+        catch {
+            Logger.shared.e(Self.TAG, error.localizedDescription)
+            return nil
+        }
     }
     
     public func toMap() -> [String : Any?] {
@@ -114,7 +122,7 @@ public class NotificationChannelModel : AbstractModel {
         if(locked != nil) {mapData[Definitions.NOTIFICATION_LOCKED] = self.locked}
         if(onlyAlertOnce != nil) {mapData[Definitions.NOTIFICATION_ONLY_ALERT_ONCE] = self.onlyAlertOnce}
         
-        if(criticalAlerts != nil) {mapData[Definitions.NOTIFICATION_CHANNEL_CRITICAL_ALERTS] = self.locked}
+        if(criticalAlerts != nil) {mapData[Definitions.NOTIFICATION_CHANNEL_CRITICAL_ALERTS] = self.criticalAlerts}
 
         if(defaultPrivacy != nil) {mapData[Definitions.NOTIFICATION_DEFAULT_PRIVACY] = self.defaultPrivacy?.rawValue}
         

--- a/ios/AwnCore/Classes/models/NotificationContentModel.swift
+++ b/ios/AwnCore/Classes/models/NotificationContentModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UserNotifications
 
 public class NotificationContentModel : AbstractModel {
     
@@ -19,10 +20,15 @@ public class NotificationContentModel : AbstractModel {
     public var summary: String?
     public var showWhen: Bool?
     
-    public var actionButtons:[NotificationButtonModel]?
+    public var titleLocKey:String?
+    public var bodyLocKey:String?
+    public var titleLocArgs:[String]?
+    public var bodyLocArgs:[String]?
+    
     public var payload:[String:String?]?
     
     public var wakeUpScreen: Bool?
+    public var criticalAlert: Bool?
     public var playSound: Bool?
     public var customSound: String?
     public var locked: Bool?
@@ -58,28 +64,28 @@ public class NotificationContentModel : AbstractModel {
     public init(){}
     
     func registerCreateEvent(
-        inLifeCycle lifeCycle: NotificationLifeCycle,
+        withDisplayedDate createdDate: RealDateTime = RealDateTime.init(
+            fromTimeZone: TimeZone(identifier: "UTC")
+        ),
+        withLifeCycle lifeCycle: NotificationLifeCycle,
         fromSource createdSource: NotificationSource
     ) -> Bool {
-        if(self.createdDate == nil){
-            self.createdSource = createdSource
-            self.createdLifeCycle = lifeCycle
-            self.createdDate =
-                    RealDateTime.init(
-                        fromTimeZone: RealDateTime.utcTimeZone)
-            
-            return true
-        }
-        return false
+        if self.createdDate != nil { return false }
+        self.createdSource = createdSource
+        self.createdLifeCycle = lifeCycle
+        self.createdDate = createdDate
+        return true
     }
     
     public func registerDisplayedEvent(
-        inLifeCycle lifeCycle: NotificationLifeCycle
+        withDisplayedDate displayedDate: RealDateTime = RealDateTime.init(
+            fromTimeZone: TimeZone(identifier: "UTC")
+        ),
+        withLifeCycle lifeCycle: NotificationLifeCycle
     ){
+        if self.displayedDate != nil { return }
         self.displayedLifeCycle = lifeCycle
-        self.displayedDate =
-                RealDateTime.init(
-                    fromTimeZone: TimeZone(identifier: "UTC"))
+        self.displayedDate = displayedDate
     }
     
     public func registerLastDisplayedEvent(
@@ -94,7 +100,7 @@ public class NotificationContentModel : AbstractModel {
             
             if schedule == nil {
                 registerDisplayedEvent(
-                    inLifeCycle: lifeCycle
+                    withLifeCycle: lifeCycle
                 )
             }
             else {
@@ -109,8 +115,10 @@ public class NotificationContentModel : AbstractModel {
         }
     }
     
-    public func fromMap(arguments: [String : Any?]?) -> AbstractModel? {
-                
+    public convenience init?(fromMap arguments: [String : Any?]?){
+        if arguments?.isEmpty ?? true { return nil }
+        
+        self.init()
         self.id = MapUtils<Int>.getValueOrDefault(reference: Definitions.NOTIFICATION_ID, arguments: arguments)
         if((id ?? -1) < 0) {
             id = IntUtils.generateNextRandomId();
@@ -125,10 +133,16 @@ public class NotificationContentModel : AbstractModel {
         self.summary        = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_SUMMARY, arguments: arguments)
         self.showWhen       = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_SHOW_WHEN, arguments: arguments)
         
+        self.titleLocKey    = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_TITLE_KEY, arguments: arguments)
+        self.bodyLocKey     = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_BODY_KEY, arguments: arguments)
+        self.titleLocArgs   = MapUtils<[String]>.getValueOrDefault(reference: Definitions.NOTIFICATION_TITLE_ARGS, arguments: arguments)
+        self.bodyLocArgs    = MapUtils<[String]>.getValueOrDefault(reference: Definitions.NOTIFICATION_BODY_ARGS, arguments: arguments)
+        
         self.playSound             = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_PLAY_SOUND, arguments: arguments)
         self.customSound           = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CUSTOM_SOUND, arguments: arguments)
         
         self.wakeUpScreen          = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_WAKE_UP_SCREEN, arguments: arguments)
+        self.criticalAlert         = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_CRITICAL_ALERT, arguments: arguments)
         self.locked                = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_LOCKED, arguments: arguments)
         self.icon                  = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_ICON, arguments: arguments)
         self.largeIcon             = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_LARGE_ICON, arguments: arguments)
@@ -167,8 +181,6 @@ public class NotificationContentModel : AbstractModel {
         if StringUtils.shared.isNullOrEmpty(self.bigPicture, considerWhiteSpaceAsEmpty: true) {
             self.bigPicture = nil
         }
-        
-        return self
     }
     
     public func toMap() -> [String : Any?] {
@@ -179,8 +191,16 @@ public class NotificationContentModel : AbstractModel {
         if(self.groupKey != nil) {mapData[Definitions.NOTIFICATION_GROUP_KEY] = self.groupKey}
         if(self.title != nil){ mapData[Definitions.NOTIFICATION_TITLE] = self.title }
         if(self.body != nil){ mapData[Definitions.NOTIFICATION_BODY] = self.body }
+        
+        
+        if(self.titleLocKey != nil){ mapData[Definitions.NOTIFICATION_TITLE_KEY] = self.titleLocKey }
+        if(self.bodyLocKey != nil){ mapData[Definitions.NOTIFICATION_BODY_KEY] = self.bodyLocKey }
+        if(self.titleLocArgs != nil){ mapData[Definitions.NOTIFICATION_TITLE_ARGS] = self.titleLocArgs }
+        if(self.bodyLocArgs != nil){ mapData[Definitions.NOTIFICATION_BODY_ARGS] = self.bodyLocArgs }
+        
         if(self.summary != nil){ mapData[Definitions.NOTIFICATION_SUMMARY] = self.summary }
         if(self.wakeUpScreen != nil){ mapData[Definitions.NOTIFICATION_WAKE_UP_SCREEN] = self.wakeUpScreen }
+        if(self.criticalAlert != nil){ mapData[Definitions.NOTIFICATION_CRITICAL_ALERT] = self.criticalAlert }
         if(self.showWhen != nil){ mapData[Definitions.NOTIFICATION_SHOW_WHEN] = self.showWhen }
         if(self.playSound != nil){ mapData[Definitions.NOTIFICATION_PLAY_SOUND] = self.playSound }
         if(self.customSound != nil){ mapData[Definitions.NOTIFICATION_CUSTOM_SOUND] = self.customSound }
@@ -215,13 +235,13 @@ public class NotificationContentModel : AbstractModel {
     
     func _processRetroCompatibility(fromArguments arguments: [String : Any?]?){
         if arguments?["autoCancel"] != nil {
-            Logger.w(NotificationButtonModel.TAG, "autoCancel is deprecated. Please use autoDismissible instead.")
+            Logger.shared.w(NotificationButtonModel.TAG, "autoCancel is deprecated. Please use autoDismissible instead.")
             autoDismissible = MapUtils<Bool>.getValueOrDefault(reference: "autoCancel", arguments: arguments)
         }
     }
     
     public func validate() throws {
-
+        
         if(IntUtils.isNullOrEmpty(id)){
             throw ExceptionFactory
                     .shared
@@ -267,15 +287,6 @@ public class NotificationContentModel : AbstractModel {
     }
     
     private func validateRequiredImages() throws {
-        if bigPicture == nil && largeIcon == nil {
-            throw ExceptionFactory
-                    .shared
-                    .createNewAwesomeException(
-                        className: NotificationContentModel.TAG,
-                        code: ExceptionCode.CODE_MISSING_ARGUMENTS,
-                        message: "bigPicture or largeIcon is required",
-                        detailedCode: ExceptionCode.DETAILED_REQUIRED_ARGUMENTS+".image.required")
-        }
     }
     
     private func validateIcon(_ icon:String?) throws {

--- a/ios/AwnCore/Classes/utils/CriticalAlertUtils.swift
+++ b/ios/AwnCore/Classes/utils/CriticalAlertUtils.swift
@@ -1,0 +1,54 @@
+//
+//  CriticalAlertUtils.swift
+//  awesome_notifications
+//
+
+import Foundation
+import UserNotifications
+
+@available(iOS 10.0, *)
+public class CriticalAlertUtils {
+
+    private static let TAG = "CriticalAlertUtils"
+    private static var cachedCanDeliver: Bool?
+
+    public static func updateCache(from settings: UNNotificationSettings) {
+        if #available(iOS 12.0, *) {
+            cachedCanDeliver = settings.criticalAlertSetting == .enabled
+        } else {
+            cachedCanDeliver = false
+        }
+    }
+
+    public static func clearCache() {
+        cachedCanDeliver = nil
+    }
+
+    public static func canDeliverCriticalAlerts() -> Bool {
+        if let cachedCanDeliver = cachedCanDeliver {
+            return cachedCanDeliver
+        }
+
+        var canDeliver = false
+        let semaphore = DispatchSemaphore(value: 0)
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            if #available(iOS 12.0, *) {
+                canDeliver = settings.criticalAlertSetting == .enabled
+            }
+            cachedCanDeliver = canDeliver
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + 2)
+        return canDeliver
+    }
+
+    public static func isCriticalAlertRequested(
+        channel: NotificationChannelModel,
+        notificationModel: NotificationModel
+    ) -> Bool {
+        return (channel.criticalAlerts ?? false) ||
+            (notificationModel.content?.criticalAlert ?? false)
+    }
+}


### PR DESCRIPTION
## Summary

Adds iOS Critical Alerts support in the plugin and example: permission flow, delivery guards, models, and developer documentation.

## What changed

**iOS native layer**
- PermissionManager: false positive handling, full auth bundle, explicit `self.`
- CriticalAlertUtils and NotificationBuilder: guarded critical delivery
- Channel and content models: `criticalAlerts` / `criticalAlert` flags
- NotificationPermissionStatus enum

**Example app**
- Critical alert notification demo
- Entitlements guidance in Runner
- Helper in notifications util

**README**
- Critical Alerts setup and usage

## Why

Plugin consumers need the same permission and delivery fixes as IosAwnCore, plus a working example for Apple-approved apps.

## Test plan

- [ ] `flutter test` — core suite passes
- [ ] Device validation with Critical Alerts entitlement